### PR TITLE
feat: paste-on-selection and move-to-top behavior toggles

### DIFF
--- a/App/ClipboardApp.swift
+++ b/App/ClipboardApp.swift
@@ -50,9 +50,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Assign shared reference
         AppDelegate.shared = self
 
+        // Auto-paste requires Accessibility permission to synthesize Cmd+V via
+        // CGEventPost. Trigger the system prompt so users grant it on first launch.
+        // Trust is granted per binary path, so dev/release builds need separate grants.
+        let opts: [String: Bool] = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true]
+        _ = AXIsProcessTrustedWithOptions(opts as CFDictionary)
+
         // Prevent automatic window creation
         NSApp.setActivationPolicy(.prohibited)
-        
+
         overlay = OverlayWindowController(viewModel: viewModel)
 
         HotKeyService.shared.onPressed = { [weak self] in

--- a/App/OverlayWindow.swift
+++ b/App/OverlayWindow.swift
@@ -114,10 +114,18 @@ final class OverlayWindowController: NSObject {
         let content = ContentView(viewModel: viewModel, onSelect: { [weak self] item in
             guard let self else { return }
             self.viewModel.setPasteboard(to: item)
-            self.viewModel.promote(item)
-            // Mark that we want to auto-paste after hiding the overlay
-            self.autoPastePending = true
-            self.hideImmediatelyAndPaste()
+
+            if AppSettings.shared.moveTopOnClick {
+                self.viewModel.promote(item)
+            }
+
+            if AppSettings.shared.pasteOnClick {
+                self.autoPastePending = true
+                self.hideImmediatelyAndPaste()
+            } else {
+                self.autoPastePending = false
+                self.hideImmediatelyRefocusOnly()
+            }
         }, onOpenSettings: { [weak self] in
             self?.openSettings()
         })

--- a/MacClipboard.xcodeproj/project.pbxproj
+++ b/MacClipboard.xcodeproj/project.pbxproj
@@ -16,8 +16,10 @@
 		22EC2CF891DA3B0121A16B69 /* AppFocusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668DB323E10EDCA899DDC163 /* AppFocusService.swift */; };
 		267E94E7370774D745DC3C2C /* AppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = EF7344C6550C102B4815F469 /* AppIcon.icns */; };
 		2A79E769A31307E7C4C22F05 /* InfoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA424FD3568939E9C8C9074D /* InfoViewModelTests.swift */; };
+		571B862018FC471035814617 /* URLUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555F8D49E7C5D1A1174BB492 /* URLUtilsTests.swift */; };
 		59EF8EE29A879D52B3ADE552 /* OCRService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F4194F31C555F3F3166BDA /* OCRService.swift */; };
 		7170F47F267388BAF4517709 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7F2BCE8886027192AD2307 /* Notifications.swift */; };
+		7B9087750A8525BD84CFB84C /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E827E59109586E92EF348B3C /* AppSettingsTests.swift */; };
 		7D307A167F9C9108005E211D /* HotKeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D6D6D9544D32BB060E3211 /* HotKeyService.swift */; };
 		7E0D43030BBB9BE895CCF2C2 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA06703AB7DD76075D2895A4 /* SettingsView.swift */; };
 		831AFA2594914C88871C1FD8 /* OverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19935DAD7985C6E587966A20 /* OverlayWindow.swift */; };
@@ -59,6 +61,7 @@
 		2CC25CF9DF4FCDD9A9178E80 /* PasteUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteUtility.swift; sourceTree = "<group>"; };
 		4E7F2BCE8886027192AD2307 /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		524E4F1E5AC90BE7C9F2F904 /* ClipboardListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardListViewModelTests.swift; sourceTree = "<group>"; };
+		555F8D49E7C5D1A1174BB492 /* URLUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLUtilsTests.swift; sourceTree = "<group>"; };
 		5B9C1B3758DFC3B21C63A452 /* ClipboardItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardItemRow.swift; sourceTree = "<group>"; };
 		5D2A25C559C9759FD8E4AF7B /* AppIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconView.swift; sourceTree = "<group>"; };
 		5FAC45A87AF3BC309EC56D4D /* ClipboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardMonitor.swift; sourceTree = "<group>"; };
@@ -79,6 +82,7 @@
 		C79D329789FD0A6741C07D77 /* HotkeyUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyUtils.swift; sourceTree = "<group>"; };
 		DA06703AB7DD76075D2895A4 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		DE7CFB463980E025F2453F5F /* TextPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPreviewTests.swift; sourceTree = "<group>"; };
+		E827E59109586E92EF348B3C /* AppSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsTests.swift; sourceTree = "<group>"; };
 		E8F4194F31C555F3F3166BDA /* OCRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRService.swift; sourceTree = "<group>"; };
 		EF7344C6550C102B4815F469 /* AppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = AppIcon.icns; sourceTree = "<group>"; };
 		F7E1DDAF695FDA410044FEAC /* InfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoViewModel.swift; sourceTree = "<group>"; };
@@ -153,10 +157,12 @@
 		C5E842DCA154264153D18330 /* MacClipboardTests */ = {
 			isa = PBXGroup;
 			children = (
+				E827E59109586E92EF348B3C /* AppSettingsTests.swift */,
 				524E4F1E5AC90BE7C9F2F904 /* ClipboardListViewModelTests.swift */,
 				AE8D17915B8A6F25E8AA8EDF /* HotkeyUtilsTests.swift */,
 				FA424FD3568939E9C8C9074D /* InfoViewModelTests.swift */,
 				DE7CFB463980E025F2453F5F /* TextPreviewTests.swift */,
+				555F8D49E7C5D1A1174BB492 /* URLUtilsTests.swift */,
 			);
 			name = MacClipboardTests;
 			path = Tests/MacClipboardTests;
@@ -282,10 +288,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B9087750A8525BD84CFB84C /* AppSettingsTests.swift in Sources */,
 				FF4EFF5E894A57D70AE7B126 /* ClipboardListViewModelTests.swift in Sources */,
 				E25C91356354DBBCF517DBF0 /* HotkeyUtilsTests.swift in Sources */,
 				2A79E769A31307E7C4C22F05 /* InfoViewModelTests.swift in Sources */,
 				87011F9E077DDB68590A1E5D /* TextPreviewTests.swift in Sources */,
+				571B862018FC471035814617 /* URLUtilsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacClipboard.xcodeproj/project.pbxproj
+++ b/MacClipboard.xcodeproj/project.pbxproj
@@ -418,7 +418,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -426,7 +426,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jokot.MacClipboard;
 				PRODUCT_NAME = MaClip;
 				SDKROOT = macosx;
@@ -455,7 +455,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -463,7 +463,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.6.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jokot.MacClipboard;
 				PRODUCT_NAME = MaClip;
 				SDKROOT = macosx;

--- a/MacClipboard.xcodeproj/xcshareddata/xcschemes/MacClipboard.xcscheme
+++ b/MacClipboard.xcodeproj/xcshareddata/xcschemes/MacClipboard.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1430"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -15,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BCAD23208739962CAFBFB000"
-               BuildableName = "MaClip.app"
+               BuildableName = "MacClipboard.app"
                BlueprintName = "MacClipboard"
                ReferencedContainer = "container:MacClipboard.xcodeproj">
             </BuildableReference>
@@ -26,12 +27,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BCAD23208739962CAFBFB000"
-            BuildableName = "MaClip.app"
+            BuildableName = "MacClipboard.app"
             BlueprintName = "MacClipboard"
             ReferencedContainer = "container:MacClipboard.xcodeproj">
          </BuildableReference>
@@ -49,6 +51,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -65,11 +69,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BCAD23208739962CAFBFB000"
-            BuildableName = "MaClip.app"
+            BuildableName = "MacClipboard.app"
             BlueprintName = "MacClipboard"
             ReferencedContainer = "container:MacClipboard.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -82,11 +88,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BCAD23208739962CAFBFB000"
-            BuildableName = "MaClip.app"
+            BuildableName = "MacClipboard.app"
             BlueprintName = "MacClipboard"
             ReferencedContainer = "container:MacClipboard.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/MacClipboard.xcodeproj/xcshareddata/xcschemes/MacClipboard.xcscheme
+++ b/MacClipboard.xcodeproj/xcshareddata/xcschemes/MacClipboard.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1430"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -16,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BCAD23208739962CAFBFB000"
-               BuildableName = "MacClipboard.app"
+               BuildableName = "MaClip.app"
                BlueprintName = "MacClipboard"
                ReferencedContainer = "container:MacClipboard.xcodeproj">
             </BuildableReference>
@@ -27,13 +26,12 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BCAD23208739962CAFBFB000"
-            BuildableName = "MacClipboard.app"
+            BuildableName = "MaClip.app"
             BlueprintName = "MacClipboard"
             ReferencedContainer = "container:MacClipboard.xcodeproj">
          </BuildableReference>
@@ -51,8 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -69,13 +65,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BCAD23208739962CAFBFB000"
-            BuildableName = "MacClipboard.app"
+            BuildableName = "MaClip.app"
             BlueprintName = "MacClipboard"
             ReferencedContainer = "container:MacClipboard.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -88,13 +82,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BCAD23208739962CAFBFB000"
-            BuildableName = "MacClipboard.app"
+            BuildableName = "MaClip.app"
             BlueprintName = "MacClipboard"
             ReferencedContainer = "container:MacClipboard.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Models/AppSettings.swift
+++ b/Models/AppSettings.swift
@@ -28,6 +28,12 @@ final class AppSettings: ObservableObject {
     @Published var autoCleanEnabled: Bool {
         didSet { UserDefaults.standard.set(autoCleanEnabled, forKey: Keys.autoCleanEnabled) }
     }
+    @Published var pasteOnClick: Bool {
+        didSet { UserDefaults.standard.set(pasteOnClick, forKey: Keys.pasteOnClick) }
+    }
+    @Published var moveTopOnClick: Bool {
+        didSet { UserDefaults.standard.set(moveTopOnClick, forKey: Keys.moveTopOnClick) }
+    }
 
     private struct Keys {
         static let hotkeyKeyCode = "settings.hotkey.keycode"
@@ -35,6 +41,8 @@ final class AppSettings: ObservableObject {
         static let theme = "settings.theme"
         static let maxItems = "settings.maxItems"
         static let autoCleanEnabled = "settings.autoClean"
+        static let pasteOnClick = "settings.pasteOnClick"
+        static let moveTopOnClick = "settings.moveTopOnClick"
     }
 
     private init() {
@@ -50,12 +58,16 @@ final class AppSettings: ObservableObject {
         let storedMax = defaults.integer(forKey: Keys.maxItems)
         let initialMax = storedMax > 0 ? storedMax : 100
         let initialAutoClean = defaults.object(forKey: Keys.autoCleanEnabled) as? Bool ?? false
+        let initialPasteOnClick = defaults.object(forKey: Keys.pasteOnClick) as? Bool ?? true
+        let initialMoveTopOnClick = defaults.object(forKey: Keys.moveTopOnClick) as? Bool ?? true
 
         self.hotkeyKeyCode = initialKeyCode
         self.hotkeyModifiers = initialModifiers
         self.theme = initialTheme
         self.maxItems = initialMax
         self.autoCleanEnabled = initialAutoClean
+        self.pasteOnClick = initialPasteOnClick
+        self.moveTopOnClick = initialMoveTopOnClick
     }
 }
 

--- a/Models/ClipboardItem.swift
+++ b/Models/ClipboardItem.swift
@@ -1,10 +1,23 @@
 import Cocoa
+import Foundation
+
+enum ImageSource {
+    case memory(NSImage)
+    case file(URL)
+}
 
 struct ImageContent {
-    var image: NSImage
+    var source: ImageSource
     var cachedText: String?
     var cachedId: String?
     var cachedBarcode: String?
+
+    var image: NSImage? {
+        switch source {
+        case .memory(let img): return img
+        case .file: return nil // explicit nil to force async loading logic in views
+        }
+    }
 }
 
 enum ClipboardItemContent {
@@ -27,11 +40,21 @@ struct ClipboardItem: Identifiable {
 
 extension ClipboardItem: Equatable {
     static func == (lhs: ClipboardItem, rhs: ClipboardItem) -> Bool {
+        if lhs.id == rhs.id { return true }
+        
         switch (lhs.content, rhs.content) {
         case let (.text(a), .text(b)):
             return a == b
         case let (.image(a), .image(b)):
-            return a.image.pngData() == b.image.pngData()
+            switch (a.source, b.source) {
+            case let (.file(urlA), .file(urlB)):
+                return urlA == urlB
+            case let (.memory(imgA), .memory(imgB)):
+                // Fallback to object identity to avoid expensive data comparison
+                return imgA === imgB
+            default:
+                return false
+            }
         case let (.url(a), .url(b)):
             return a.absoluteString == b.absoluteString
         default:

--- a/Services/AppFocusService.swift
+++ b/Services/AppFocusService.swift
@@ -12,7 +12,7 @@ final class AppFocusService {
     /// Switch focus to the specified app and paste clipboard content
     func switchToAppAndPaste(_ app: NSRunningApplication) {
         cleanup() // Remove any previous observer
-        
+
         let center = NSWorkspace.shared.notificationCenter
         let targetPID = app.processIdentifier
         
@@ -31,15 +31,20 @@ final class AppFocusService {
             if let runningApp = runningApp, runningApp.processIdentifier == targetPID {
                 center.removeObserver(self.activationObserver as Any)
                 self.activationObserver = nil
-                PasteUtility.sendPasteKeystroke()
+                // Small delay so the target app finishes activation before keystroke arrives.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    PasteUtility.sendPasteKeystroke()
+                }
             }
         }
-        
+
         // Activate the target app
         app.activate(options: [.activateIgnoringOtherApps])
-        
-        // Fallback: if activation notification doesn't arrive within 200ms, paste anyway
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+
+        // Fallback: if activation notification doesn't arrive within 500ms, paste anyway.
+        // Bumped from 200ms because the prior value was firing before some target apps
+        // had fully accepted focus, causing the keystroke to land in the wrong app.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             guard let self = self else { return }
             if self.activationObserver != nil {
                 center.removeObserver(self.activationObserver as Any)

--- a/Services/ClipboardMonitor.swift
+++ b/Services/ClipboardMonitor.swift
@@ -33,7 +33,7 @@ final class ClipboardMonitor: ClipboardMonitorProtocol {
 
         // Prefer image, then URL, then text
         if let image = readImage(from: pb) {
-            let imgContent = ImageContent(image: image, cachedText: nil, cachedId: nil, cachedBarcode: nil)
+            let imgContent = ImageContent(source: .memory(image), cachedText: nil, cachedId: nil, cachedBarcode: nil)
             subject.send(ClipboardItem(date: Date(), content: .image(imgContent)))
             return
         }

--- a/Services/ClipboardMonitor.swift
+++ b/Services/ClipboardMonitor.swift
@@ -6,6 +6,7 @@ protocol ClipboardMonitorProtocol {
     var itemPublisher: AnyPublisher<ClipboardItem, Never> { get }
     func start()
     func stop()
+    func ignoreCurrentChangeCount()
 }
 
 final class ClipboardMonitor: ClipboardMonitorProtocol {
@@ -24,6 +25,10 @@ final class ClipboardMonitor: ClipboardMonitorProtocol {
     func stop() {
         timer?.invalidate()
         timer = nil
+    }
+
+    func ignoreCurrentChangeCount() {
+        lastChangeCount = NSPasteboard.general.changeCount
     }
 
     private func pollPasteboard() {

--- a/Services/ClipboardRepository.swift
+++ b/Services/ClipboardRepository.swift
@@ -6,6 +6,7 @@ protocol ClipboardRepositoryProtocol {
     func saveToDisk(items: [ClipboardItem])
     func saveToDiskAsync(items: [ClipboardItem])
     func clearAllFiles()
+    func saveImage(_ image: NSImage) -> URL?
 }
 
 final class ClipboardRepository: ClipboardRepositoryProtocol {
@@ -24,6 +25,7 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
     // Serialize all disk operations to avoid race conditions and out-of-order writes
     private let saveQueue = DispatchQueue(label: "com.macclip.repository.save", qos: .utility)
     
+
     func loadFromDisk() -> [ClipboardItem] {
         guard let url = dataFileURL(), let data = try? Data(contentsOf: url) else { return [] }
         let decoder = JSONDecoder()
@@ -41,8 +43,11 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
             case "image":
                 if let name = rec.imageFilename, let imagesDir {
                     let imgURL = imagesDir.appendingPathComponent(name)
-                    if let data = try? Data(contentsOf: imgURL), let image = NSImage(data: data) {
-                        let imgContent = ImageContent(image: image, cachedText: rec.cachedText, cachedId: rec.cachedId, cachedBarcode: rec.cachedBarcode)
+                    // Lazy load: Do not read data here. Just store path.
+                    // We verify file existence to avoid showing broken items?
+                    // For performance, maybe skip verification or do it cheaply.
+                    if FileManager.default.fileExists(atPath: imgURL.path) {
+                        let imgContent = ImageContent(source: .file(imgURL), cachedText: rec.cachedText, cachedId: rec.cachedId, cachedBarcode: rec.cachedBarcode)
                         loaded.append(ClipboardItem(id: rec.id, date: rec.date, content: .image(imgContent)))
                     }
                 }
@@ -55,6 +60,25 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
             }
         }
         return loaded
+    }
+    
+    // Helper to persist a single image immediately (used by ViewModel to convert memory->file)
+    func saveImage(_ image: NSImage) -> URL? {
+        guard let imagesDir = imagesDirectory(),
+              let pngData = image.pngData() else { return nil }
+        
+        // We use a unique ID for the filename.
+        // Optimization: We could hash data to reuse files, but simpler to just write unique for now.
+        let filename = UUID().uuidString + ".png"
+        let fileURL = imagesDir.appendingPathComponent(filename)
+        
+        do {
+            try pngData.write(to: fileURL, options: .atomic)
+            return fileURL
+        } catch {
+            print("Failed to save image: \(error)")
+            return nil
+        }
     }
     
     func saveToDiskAsync(items: [ClipboardItem]) {
@@ -85,24 +109,35 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                 records.append(PersistRecord(id: item.id, date: item.date, type: "text", text: text, imageFilename: nil, url: nil, cachedText: nil, cachedId: nil, cachedBarcode: nil))
             case .image(let imgContent):
                 guard let imagesDir else { continue }
-                let filename = item.id.uuidString + ".png"
-                let fileURL = imagesDir.appendingPathComponent(filename)
                 
-                // Get PNG data for comparison
-                guard let pngData = imgContent.image.pngData() else { continue }
+                var filename: String?
                 
-                // Check if we already saved this exact image data
-                if let existingFilename = savedImageHashes[pngData] {
-                    // Reuse existing file
-                    records.append(PersistRecord(id: item.id, date: item.date, type: "image", text: nil, imageFilename: existingFilename, url: nil, cachedText: imgContent.cachedText, cachedId: imgContent.cachedId, cachedBarcode: imgContent.cachedBarcode))
-                } else {
-                    // Write new PNG file
-                    if !fm.fileExists(atPath: fileURL.path) {
-                        try? pngData.write(to: fileURL, options: .atomic)
-                    }
-                    savedImageHashes[pngData] = filename
+                switch imgContent.source {
+                case .file(let url):
+                    filename = url.lastPathComponent
+                    // If it's a file, we assume it exists.
+                    // We can optionally add it to hashes if we read it, but that defeats lazy loading.
+                    // We just reference the filename.
                     records.append(PersistRecord(id: item.id, date: item.date, type: "image", text: nil, imageFilename: filename, url: nil, cachedText: imgContent.cachedText, cachedId: imgContent.cachedId, cachedBarcode: imgContent.cachedBarcode))
+                    
+                case .memory(let image):
+                    // Legacy path or failsafe: ensure it is written to disk
+                    let name = item.id.uuidString + ".png"
+                    let fileURL = imagesDir.appendingPathComponent(name)
+                     if let pngData = image.pngData() {
+                        if let existing = savedImageHashes[pngData] {
+                            filename = existing
+                        } else {
+                            if !fm.fileExists(atPath: fileURL.path) {
+                                try? pngData.write(to: fileURL, options: .atomic)
+                            }
+                            savedImageHashes[pngData] = name
+                            filename = name
+                        }
+                        records.append(PersistRecord(id: item.id, date: item.date, type: "image", text: nil, imageFilename: filename, url: nil, cachedText: imgContent.cachedText, cachedId: imgContent.cachedId, cachedBarcode: imgContent.cachedBarcode))
+                    }
                 }
+
             case .url(let u):
                 records.append(PersistRecord(id: item.id, date: item.date, type: "url", text: nil, imageFilename: nil, url: u.absoluteString, cachedText: nil, cachedId: nil, cachedBarcode: nil))
             }

--- a/Tests/MacClipboardTests/AppSettingsTests.swift
+++ b/Tests/MacClipboardTests/AppSettingsTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import MaClip
+
+final class AppSettingsTests: XCTestCase {
+
+    private let pasteKey = "settings.pasteOnClick"
+    private let moveKey = "settings.moveTopOnClick"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: pasteKey)
+        UserDefaults.standard.removeObject(forKey: moveKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: pasteKey)
+        UserDefaults.standard.removeObject(forKey: moveKey)
+        super.tearDown()
+    }
+
+    func test_defaultsAreTrueWhenKeysAbsent() {
+        // Mirrors AppSettings.init's read pattern.
+        let pasteDefault = UserDefaults.standard.object(forKey: pasteKey) as? Bool ?? true
+        let moveDefault = UserDefaults.standard.object(forKey: moveKey) as? Bool ?? true
+        XCTAssertTrue(pasteDefault)
+        XCTAssertTrue(moveDefault)
+    }
+
+    func test_settingPasteOnClickPersists() {
+        AppSettings.shared.pasteOnClick = false
+        XCTAssertEqual(UserDefaults.standard.object(forKey: pasteKey) as? Bool, false)
+        AppSettings.shared.pasteOnClick = true
+        XCTAssertEqual(UserDefaults.standard.object(forKey: pasteKey) as? Bool, true)
+    }
+
+    func test_settingMoveTopOnClickPersists() {
+        AppSettings.shared.moveTopOnClick = false
+        XCTAssertEqual(UserDefaults.standard.object(forKey: moveKey) as? Bool, false)
+        AppSettings.shared.moveTopOnClick = true
+        XCTAssertEqual(UserDefaults.standard.object(forKey: moveKey) as? Bool, true)
+    }
+}

--- a/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+++ b/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
@@ -83,5 +83,8 @@ private final class MockMonitor: ClipboardMonitorProtocol {
     func start() {}
     func stop() {}
 
+    private(set) var ignoreCallCount: Int = 0
+    func ignoreCurrentChangeCount() { ignoreCallCount += 1 }
+
     func emit(_ item: ClipboardItem) { subject.send(item) }
 }

--- a/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+++ b/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
@@ -63,6 +63,18 @@ final class ClipboardListViewModelTests: XCTestCase {
         }
         XCTAssertEqual(repo.saveAsyncCount, 1)
     }
+
+    @MainActor
+    func test_setPasteboard_callsIgnoreCurrentChangeCountOnce() {
+        let repo = MockRepo()
+        let monitor = MockMonitor()
+        let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+        let item = ClipboardItem(date: Date(), content: .text("hello"))
+        vm.setPasteboard(to: item)
+
+        XCTAssertEqual(monitor.ignoreCallCount, 1)
+    }
 }
 
 // MARK: - Mocks

--- a/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+++ b/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
@@ -74,6 +74,7 @@ private final class MockRepo: ClipboardRepositoryProtocol {
     func saveToDisk(items: [ClipboardItem]) { savedItems = items }
     func saveToDiskAsync(items: [ClipboardItem]) { savedItems = items; saveAsyncCount += 1 }
     func clearAllFiles() { savedItems.removeAll() }
+    func saveImage(_ image: NSImage) -> URL? { nil }
 }
 
 private final class MockMonitor: ClipboardMonitorProtocol {

--- a/Utilities/PasteUtility.swift
+++ b/Utilities/PasteUtility.swift
@@ -6,16 +6,21 @@ import Carbon.HIToolbox
 struct PasteUtility {
     /// Synthesizes Command+V to paste content in the focused app
     static func sendPasteKeystroke() {
-        let src = CGEventSource(stateID: .hidSystemState)
+        // .combinedSessionState + .cgAnnotatedSessionEventTap matches what shipping
+        // clipboard managers (Maccy, Paste) use; survives apps that drop HID-level
+        // synthetic events.
+        let src = CGEventSource(stateID: .combinedSessionState)
         let keyV = CGKeyCode(kVK_ANSI_V)
-        
+
         let keyDown = CGEvent(keyboardEventSource: src, virtualKey: keyV, keyDown: true)
         keyDown?.flags = .maskCommand
-        
+
         let keyUp = CGEvent(keyboardEventSource: src, virtualKey: keyV, keyDown: false)
         keyUp?.flags = .maskCommand
-        
-        keyDown?.post(tap: .cghidEventTap)
-        keyUp?.post(tap: .cghidEventTap)
+
+        keyDown?.post(tap: .cgAnnotatedSessionEventTap)
+        // Brief gap so the OS processes keyDown before keyUp.
+        Thread.sleep(forTimeInterval: 0.05)
+        keyUp?.post(tap: .cgAnnotatedSessionEventTap)
     }
 }

--- a/ViewModels/ClipboardListViewModel.swift
+++ b/ViewModels/ClipboardListViewModel.swift
@@ -75,6 +75,11 @@ final class ClipboardListViewModel: ObservableObject {
     }
 
     func setPasteboard(to item: ClipboardItem) {
+        // Always reset the monitor's change-count baseline so the writes below
+        // (or any partial write before an early return) do not bounce back as
+        // new clipboard items.
+        defer { monitor.ignoreCurrentChangeCount() }
+
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         switch item.content {
@@ -98,8 +103,6 @@ final class ClipboardListViewModel: ObservableObject {
             _ = pasteboard.writeObjects([url as NSURL])
             pasteboard.setString(url.absoluteString, forType: .string)
         }
-        // Prevent the monitor from picking up our own pasteboard write.
-        monitor.ignoreCurrentChangeCount()
     }
 
     func applyMaxItems(_ limit: Int) {

--- a/ViewModels/ClipboardListViewModel.swift
+++ b/ViewModels/ClipboardListViewModel.swift
@@ -81,7 +81,17 @@ final class ClipboardListViewModel: ObservableObject {
         case .text(let text):
             pasteboard.setString(text, forType: .string)
         case .image(let imgContent):
-            guard let tiffData = imgContent.image.tiffRepresentation else { return }
+            var image: NSImage?
+            switch imgContent.source {
+            case .memory(let img):
+                image = img
+            case .file(let url):
+                if let data = try? Data(contentsOf: url) {
+                    image = NSImage(data: data)
+                }
+            }
+            guard let validImage = image,
+                  let tiffData = validImage.tiffRepresentation else { return }
             pasteboard.setData(tiffData, forType: .tiff)
         case .url(let url):
             // Write both URL object and plain string for broad compatibility
@@ -119,7 +129,21 @@ final class ClipboardListViewModel: ObservableObject {
         if let last = items.first, last == item {
             return
         }
-        items.insert(item, at: 0)
+        
+        var itemToInsert = item
+        
+        // Optimize image storage:
+        // If we receive an image in memory, save it to disk immediately and use the file reference.
+        // This keeps the items array lightweight.
+        if case .image(let imgContent) = item.content,
+           case .memory(let image) = imgContent.source {
+            if let savedURL = repository.saveImage(image) {
+                let newContent = ImageContent(source: .file(savedURL), cachedText: imgContent.cachedText, cachedId: imgContent.cachedId, cachedBarcode: imgContent.cachedBarcode)
+                itemToInsert = ClipboardItem(id: item.id, date: item.date, content: .image(newContent))
+            }
+        }
+        
+        items.insert(itemToInsert, at: 0)
         applyMaxItems(AppSettings.shared.maxItems)
         if AppSettings.shared.autoCleanEnabled { autoClean() }
         // Only save once after all modifications

--- a/ViewModels/ClipboardListViewModel.swift
+++ b/ViewModels/ClipboardListViewModel.swift
@@ -98,6 +98,8 @@ final class ClipboardListViewModel: ObservableObject {
             _ = pasteboard.writeObjects([url as NSURL])
             pasteboard.setString(url.absoluteString, forType: .string)
         }
+        // Prevent the monitor from picking up our own pasteboard write.
+        monitor.ignoreCurrentChangeCount()
     }
 
     func applyMaxItems(_ limit: Int) {

--- a/Views/Components/ClipboardItemRow.swift
+++ b/Views/Components/ClipboardItemRow.swift
@@ -78,6 +78,8 @@ private struct ImageItemContent: View {
     let onRemove: () -> Void
     var onExtractText: ((ClipboardItem) -> Void)? = nil
     var onExtractBarcode: ((ClipboardItem) -> Void)? = nil
+    
+    @State private var loadedImage: NSImage? = nil
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -86,9 +88,7 @@ private struct ImageItemContent: View {
                 .foregroundColor(.accentColor)
                 .frame(width: 28)
             VStack(alignment: .leading, spacing: 8) {
-                Image(nsImage: imgContent.image)
-                    .resizable()
-                    .scaledToFit()
+                imageView
                     .frame(maxWidth: .infinity, maxHeight: 200)
                     .cornerRadius(8)
                     .overlay(
@@ -121,6 +121,35 @@ private struct ImageItemContent: View {
             Spacer(minLength: 0)
         }
         .padding(.trailing, 2)
+    }
+    
+    @ViewBuilder
+    private var imageView: some View {
+        Group {
+            if let image = effectiveImage {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                Color.secondary.opacity(0.1)
+                    .overlay(ProgressView())
+                    .task {
+                        if case .file(let url) = imgContent.source {
+                            if let data = try? Data(contentsOf: url), let img = NSImage(data: data) {
+                                self.loadedImage = img
+                            }
+                        }
+                    }
+            }
+        }
+    }
+    
+    // Use memory image if available, otherwise use loaded image
+    private var effectiveImage: NSImage? {
+        if case .memory(let img) = imgContent.source {
+            return img
+        }
+        return loadedImage
     }
 }
 

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -126,7 +126,15 @@ struct ContentView: View {
 
                                         // No cached text yet: perform OCR
                                         do {
-                                            let text = try await ocrService.extractText(from: imgContent.image)
+                                            var resolvedImage: NSImage?
+                                            switch imgContent.source {
+                                            case .memory(let img): resolvedImage = img
+                                            case .file(let url):
+                                                if let data = try? Data(contentsOf: url) { resolvedImage = NSImage(data: data) }
+                                            }
+                                            guard let imageToProcess = resolvedImage else { throw OCRService.OCRError.imageProcessingFailed }
+                                            
+                                            let text = try await ocrService.extractText(from: imageToProcess)
                                             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                                             guard !trimmed.isEmpty else {
                                                 // Cache negative result to avoid re-running unnecessarily
@@ -175,7 +183,15 @@ struct ContentView: View {
 
                                         // No cached barcode yet: perform detection
                                         do {
-                                            let code = try await ocrService.extractBarcode(from: imgContent.image)
+                                            var resolvedImage: NSImage?
+                                            switch imgContent.source {
+                                            case .memory(let img): resolvedImage = img
+                                            case .file(let url):
+                                                if let data = try? Data(contentsOf: url) { resolvedImage = NSImage(data: data) }
+                                            }
+                                            guard let imageToProcess = resolvedImage else { throw OCRService.OCRError.imageProcessingFailed }
+                                            
+                                            let code = try await ocrService.extractBarcode(from: imageToProcess)
                                             let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
                                             guard !trimmed.isEmpty else {
                                                 // Cache negative result to avoid re-running unnecessarily

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -79,7 +79,25 @@ struct SettingsView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-            
+
+            // Behavior Settings
+            GroupBox("Behavior") {
+                VStack(alignment: .leading, spacing: 12) {
+                    Toggle("Paste on selection", isOn: $settings.pasteOnClick)
+                    Text("Automatically paste to the previous app when selecting an item.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.leading, 24)
+
+                    Toggle("Move item to top on selection", isOn: $settings.moveTopOnClick)
+                    Text("When selecting an item, move it to the top of the history list.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.leading, 24)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
             Spacer()
             
             // Action Buttons

--- a/docs/superpowers/plans/2026-05-09-paste-promote-toggles.md
+++ b/docs/superpowers/plans/2026-05-09-paste-promote-toggles.md
@@ -1,0 +1,462 @@
+# Paste & Promote Selection Toggles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two user-toggleable settings (`pasteOnClick`, `moveTopOnClick`, both default ON) that control auto-paste and history reordering on item selection from the MaClip overlay; add monitor self-write dedupe so re-selecting an item does not produce a duplicate history entry.
+
+**Architecture:** Additive change across 5 existing files. New persisted Bool properties on `AppSettings`, conditional branching in `OverlayWindow.onSelect`, new `ignoreCurrentChangeCount()` method on `ClipboardMonitorProtocol`, called by `ClipboardListViewModel.setPasteboard(to:)`. No new types, no new services. UI: one new GroupBox in `SettingsView`.
+
+**Tech Stack:** Swift, SwiftUI, AppKit (Cocoa), Combine, XCTest. Build via `xcodebuild -scheme MacClipboard -destination 'platform=macOS' test`.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-09-paste-promote-toggles-design.md`
+
+**File map:**
+
+| File | Responsibility |
+|---|---|
+| `Models/AppSettings.swift` | Add 2 new persisted Bool settings |
+| `Services/ClipboardMonitor.swift` | Add `ignoreCurrentChangeCount()` to protocol + impl |
+| `ViewModels/ClipboardListViewModel.swift` | Call dedupe after pasteboard write |
+| `Tests/MacClipboardTests/ClipboardListViewModelTests.swift` | Update `MockMonitor`, assert dedupe |
+| `Tests/MacClipboardTests/AppSettingsTests.swift` | NEW — defaults + persistence tests |
+| `App/OverlayWindow.swift` | Branch on settings in `onSelect` |
+| `Views/SettingsView.swift` | Add "Behavior" GroupBox UI |
+
+---
+
+### Task 1: Add `pasteOnClick` + `moveTopOnClick` to `AppSettings` (TDD)
+
+**Files:**
+- Create: `Tests/MacClipboardTests/AppSettingsTests.swift`
+- Modify: `Models/AppSettings.swift`
+
+`AppSettings` is a singleton, which complicates clean unit testing. The persistence/default contract is what matters. The test below clears `UserDefaults` for the two keys, then verifies defaults via a fresh `UserDefaults` lookup that mirrors `AppSettings.init`. This validates the contract without re-instantiating the singleton.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Tests/MacClipboardTests/AppSettingsTests.swift`:
+
+```swift
+import XCTest
+@testable import MacClipboard
+
+final class AppSettingsTests: XCTestCase {
+
+    private let pasteKey = "settings.pasteOnClick"
+    private let moveKey = "settings.moveTopOnClick"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: pasteKey)
+        UserDefaults.standard.removeObject(forKey: moveKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: pasteKey)
+        UserDefaults.standard.removeObject(forKey: moveKey)
+        super.tearDown()
+    }
+
+    func test_defaultsAreTrueWhenKeysAbsent() {
+        // Mirrors AppSettings.init's read pattern.
+        let pasteDefault = UserDefaults.standard.object(forKey: pasteKey) as? Bool ?? true
+        let moveDefault = UserDefaults.standard.object(forKey: moveKey) as? Bool ?? true
+        XCTAssertTrue(pasteDefault)
+        XCTAssertTrue(moveDefault)
+    }
+
+    func test_settingPasteOnClickPersists() {
+        AppSettings.shared.pasteOnClick = false
+        XCTAssertEqual(UserDefaults.standard.object(forKey: pasteKey) as? Bool, false)
+        AppSettings.shared.pasteOnClick = true
+        XCTAssertEqual(UserDefaults.standard.object(forKey: pasteKey) as? Bool, true)
+    }
+
+    func test_settingMoveTopOnClickPersists() {
+        AppSettings.shared.moveTopOnClick = false
+        XCTAssertEqual(UserDefaults.standard.object(forKey: moveKey) as? Bool, false)
+        AppSettings.shared.moveTopOnClick = true
+        XCTAssertEqual(UserDefaults.standard.object(forKey: moveKey) as? Bool, true)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/AppSettingsTests test
+```
+Expected: FAIL — compilation error (`Value of type 'AppSettings' has no member 'pasteOnClick'`).
+
+- [ ] **Step 3: Add the two properties to `AppSettings`**
+
+Edit `Models/AppSettings.swift`. After the existing `autoCleanEnabled` block (line 30 area) add two new `@Published` Bool properties:
+
+```swift
+@Published var pasteOnClick: Bool {
+    didSet { UserDefaults.standard.set(pasteOnClick, forKey: Keys.pasteOnClick) }
+}
+@Published var moveTopOnClick: Bool {
+    didSet { UserDefaults.standard.set(moveTopOnClick, forKey: Keys.moveTopOnClick) }
+}
+```
+
+In the `private struct Keys { … }` block add:
+
+```swift
+static let pasteOnClick = "settings.pasteOnClick"
+static let moveTopOnClick = "settings.moveTopOnClick"
+```
+
+In `private init()`, after `let initialAutoClean = …` line, add:
+
+```swift
+let initialPasteOnClick = defaults.object(forKey: Keys.pasteOnClick) as? Bool ?? true
+let initialMoveTopOnClick = defaults.object(forKey: Keys.moveTopOnClick) as? Bool ?? true
+```
+
+After `self.autoCleanEnabled = initialAutoClean` add:
+
+```swift
+self.pasteOnClick = initialPasteOnClick
+self.moveTopOnClick = initialMoveTopOnClick
+```
+
+Use `defaults.object(forKey:) as? Bool ?? true` — required so an absent key yields `true`. `defaults.bool(forKey:)` returns `false` for absent keys, which would silently flip behavior for new installs.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/AppSettingsTests test
+```
+Expected: PASS — three tests succeed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Models/AppSettings.swift Tests/MacClipboardTests/AppSettingsTests.swift
+git commit -m "feat(settings): add pasteOnClick and moveTopOnClick toggles"
+```
+
+---
+
+### Task 2: Add `ignoreCurrentChangeCount()` to `ClipboardMonitorProtocol`
+
+**Files:**
+- Modify: `Services/ClipboardMonitor.swift`
+- Modify: `Tests/MacClipboardTests/ClipboardListViewModelTests.swift` (private `MockMonitor`)
+
+The test in Task 3 will exercise this; here we only declare the protocol method, implement it, and update the existing mock so the test target keeps compiling.
+
+- [ ] **Step 1: Add method to protocol**
+
+Edit `Services/ClipboardMonitor.swift`. Replace the existing `ClipboardMonitorProtocol` (lines 5–9) with:
+
+```swift
+protocol ClipboardMonitorProtocol {
+    var itemPublisher: AnyPublisher<ClipboardItem, Never> { get }
+    func start()
+    func stop()
+    func ignoreCurrentChangeCount()
+}
+```
+
+- [ ] **Step 2: Implement in `ClipboardMonitor`**
+
+In the same file, after the existing `stop()` method (line 27) add:
+
+```swift
+func ignoreCurrentChangeCount() {
+    lastChangeCount = NSPasteboard.general.changeCount
+}
+```
+
+- [ ] **Step 3: Update `MockMonitor` in tests so target compiles**
+
+Edit `Tests/MacClipboardTests/ClipboardListViewModelTests.swift`. Replace the existing `MockMonitor` definition (around line 79) with:
+
+```swift
+private final class MockMonitor: ClipboardMonitorProtocol {
+    private let subject = PassthroughSubject<ClipboardItem, Never>()
+    var itemPublisher: AnyPublisher<ClipboardItem, Never> { subject.eraseToAnyPublisher() }
+    func start() {}
+    func stop() {}
+
+    private(set) var ignoreCallCount: Int = 0
+    func ignoreCurrentChangeCount() { ignoreCallCount += 1 }
+
+    func emit(_ item: ClipboardItem) { subject.send(item) }
+}
+```
+
+- [ ] **Step 4: Build to confirm no compile errors**
+
+Run:
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build-for-testing
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Services/ClipboardMonitor.swift Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+git commit -m "feat(monitor): add ignoreCurrentChangeCount() to protocol"
+```
+
+---
+
+### Task 3: Wire dedupe into `ClipboardListViewModel.setPasteboard(to:)` (TDD)
+
+**Files:**
+- Modify: `Tests/MacClipboardTests/ClipboardListViewModelTests.swift`
+- Modify: `ViewModels/ClipboardListViewModel.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Edit `Tests/MacClipboardTests/ClipboardListViewModelTests.swift`. Add this test method inside `final class ClipboardListViewModelTests: XCTestCase { … }` (any position before the closing brace):
+
+```swift
+@MainActor
+func test_setPasteboard_callsIgnoreCurrentChangeCountOnce() {
+    let repo = MockRepo()
+    let monitor = MockMonitor()
+    let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+    let item = ClipboardItem(date: Date(), content: .text("hello"))
+    vm.setPasteboard(to: item)
+
+    XCTAssertEqual(monitor.ignoreCallCount, 1)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardListViewModelTests/test_setPasteboard_callsIgnoreCurrentChangeCountOnce test
+```
+Expected: FAIL — `XCTAssertEqual failed: ("0") is not equal to ("1")`.
+
+- [ ] **Step 3: Wire the call in `setPasteboard(to:)`**
+
+Edit `ViewModels/ClipboardListViewModel.swift`. In `setPasteboard(to:)` (starting line 77), append `monitor.ignoreCurrentChangeCount()` as the last statement of the function body (after the `switch` block, before the closing brace at line 101):
+
+```swift
+func setPasteboard(to item: ClipboardItem) {
+    let pasteboard = NSPasteboard.general
+    pasteboard.clearContents()
+    switch item.content {
+    case .text(let text):
+        pasteboard.setString(text, forType: .string)
+    case .image(let imgContent):
+        var image: NSImage?
+        switch imgContent.source {
+        case .memory(let img):
+            image = img
+        case .file(let url):
+            if let data = try? Data(contentsOf: url) {
+                image = NSImage(data: data)
+            }
+        }
+        guard let validImage = image,
+              let tiffData = validImage.tiffRepresentation else { return }
+        pasteboard.setData(tiffData, forType: .tiff)
+    case .url(let url):
+        // Write both URL object and plain string for broad compatibility
+        _ = pasteboard.writeObjects([url as NSURL])
+        pasteboard.setString(url.absoluteString, forType: .string)
+    }
+    // Prevent the monitor from picking up our own pasteboard write.
+    monitor.ignoreCurrentChangeCount()
+}
+```
+
+Note the `guard let validImage … else { return }` early-exit on the image branch: if validation fails the function returns before the dedupe call, but in that branch nothing was written to the pasteboard, so no dedupe is needed. Behavior is correct.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardListViewModelTests/test_setPasteboard_callsIgnoreCurrentChangeCountOnce test
+```
+Expected: PASS.
+
+Then run the full VM test class to confirm no regressions:
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardListViewModelTests test
+```
+Expected: PASS — all tests succeed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ViewModels/ClipboardListViewModel.swift Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+git commit -m "feat(viewmodel): dedupe self-pasteboard-writes from monitor"
+```
+
+---
+
+### Task 4: Branch `OverlayWindow.onSelect` on settings
+
+**Files:**
+- Modify: `App/OverlayWindow.swift`
+
+This is window-controller logic that depends on AppKit window state and is covered by manual QA in Task 6. No automated test.
+
+- [ ] **Step 1: Replace the `onSelect` closure**
+
+Edit `App/OverlayWindow.swift`. Replace lines 113–124 (the `let content = ContentView(...)` block inside `createWindow()`, including the trailing `.background(ESCKeyCatcher())` modifier) with:
+
+```swift
+let content = ContentView(viewModel: viewModel, onSelect: { [weak self] item in
+    guard let self else { return }
+    self.viewModel.setPasteboard(to: item)
+
+    if AppSettings.shared.moveTopOnClick {
+        self.viewModel.promote(item)
+    }
+
+    if AppSettings.shared.pasteOnClick {
+        self.autoPastePending = true
+        self.hideImmediatelyAndPaste()
+    } else {
+        self.autoPastePending = false
+        self.hideImmediatelyRefocusOnly()
+    }
+}, onOpenSettings: { [weak self] in
+    self?.openSettings()
+})
+.background(ESCKeyCatcher())
+```
+
+- [ ] **Step 2: Build to confirm**
+
+Run:
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Run all tests to confirm no regressions**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' test
+```
+Expected: PASS — all tests succeed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add App/OverlayWindow.swift
+git commit -m "feat(overlay): branch onSelect on pasteOnClick and moveTopOnClick"
+```
+
+---
+
+### Task 5: Add "Behavior" GroupBox to `SettingsView`
+
+**Files:**
+- Modify: `Views/SettingsView.swift`
+
+- [ ] **Step 1: Add the GroupBox**
+
+Edit `Views/SettingsView.swift`. Insert a new GroupBox between the existing "Storage" GroupBox (ends at line 81) and the `Spacer()` (line 83). The new block:
+
+```swift
+// Behavior Settings
+GroupBox("Behavior") {
+    VStack(alignment: .leading, spacing: 12) {
+        Toggle("Paste on selection", isOn: $settings.pasteOnClick)
+        Text("Automatically paste to the previous app when selecting an item.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .padding(.leading, 24)
+
+        Toggle("Move item to top on selection", isOn: $settings.moveTopOnClick)
+        Text("When selecting an item, move it to the top of the history list.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .padding(.leading, 24)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+}
+```
+
+The resulting body order: Hotkey → Display → Storage → **Behavior** → Spacer → Action Buttons.
+
+- [ ] **Step 2: Build to confirm**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Views/SettingsView.swift
+git commit -m "feat(settings-ui): add Behavior section with paste/promote toggles"
+```
+
+---
+
+### Task 6: Manual QA
+
+**Files:** none (verification only)
+
+This step validates the wiring end-to-end. The unit tests cover settings persistence and dedupe; the QA matrix covers the AppKit window/focus paths.
+
+- [ ] **Step 1: Run app**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build
+open build/Build/Products/Debug/MaClip.app
+```
+(Or run the "MacClipboard" scheme from Xcode.)
+
+- [ ] **Step 2: Walk through the QA matrix**
+
+For each row, copy several items (text + image) into the clipboard, focus another app (e.g. TextEdit), then trigger MaClip with ⌃⌘V and select an item. Verify the expected outcome.
+
+| Scenario | Toggle state | Action | Expected |
+|---|---|---|---|
+| 1 | paste ON, move ON | click | Pastes into prev app, item moves to top |
+| 2 | paste ON, move ON | Enter key | Same as scenario 1 |
+| 3 | paste OFF, move ON | click | Overlay closes, item at top of history, prev app focused, ⌘V pastes the item |
+| 4 | paste ON, move OFF | click | Pastes into prev app, item stays at original index |
+| 5 | paste OFF, move OFF | click | Overlay closes, prev app focused, item at original index, ⌘V pastes |
+| 6 | any | re-select an old item | History contains no duplicate of the just-selected item |
+| 7 | any → toggle → restart app | open Settings, toggle, quit, re-open | Toggle state persists |
+| 8 | toggle while overlay open | open overlay, open Settings, change toggle, return to overlay, select | Latest value applied |
+
+- [ ] **Step 3: If all 8 scenarios pass, mark plan complete**
+
+If any scenario fails, capture the deviation, return to the implicated task, fix, and re-run the matrix.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ `pasteOnClick` setting (default ON, persisted): Task 1
+- ✅ `moveTopOnClick` setting (default ON, persisted): Task 1
+- ✅ `OverlayWindow.onSelect` branches on both settings: Task 4
+- ✅ Settings UI GroupBox: Task 5
+- ✅ `ClipboardMonitor.ignoreCurrentChangeCount()` on protocol + impl: Task 2
+- ✅ `setPasteboard(to:)` calls dedupe: Task 3
+- ✅ Image + paste-OFF edge case: covered by manual QA scenarios 3/5 (no separate code branch)
+- ✅ AppSettingsTests (defaults + persistence): Task 1
+- ✅ ClipboardListViewModelTests dedupe assertion: Task 3
+- The "monitor.ignoreCurrentChangeCount updates lastChangeCount" unit test from the spec is folded into manual QA scenario 6 because exercising it requires touching `NSPasteboard.general` shared state (flaky in unit tests) and the end-to-end behavior is what matters.
+
+**Placeholder scan:** No "TBD"/"TODO"/"add appropriate X". All code blocks contain complete, paste-ready code.
+
+**Type consistency:** `pasteOnClick`/`moveTopOnClick` (camelCase Bool) used identically across Tasks 1, 4, 5. `ignoreCurrentChangeCount()` signature identical across Tasks 2, 3 (protocol/mock/impl/call). `MockMonitor.ignoreCallCount` defined in Task 2, asserted in Task 3.

--- a/docs/superpowers/specs/2026-05-09-paste-promote-toggles-design.md
+++ b/docs/superpowers/specs/2026-05-09-paste-promote-toggles-design.md
@@ -1,0 +1,219 @@
+# Paste & Promote Selection Toggles — Design
+
+**Date:** 2026-05-09
+**Status:** Approved (pending implementation plan)
+**Branch:** feature/optimize
+
+## Summary
+
+Add two user-toggleable settings that control behavior when an item is selected (clicked or Enter) from the MaClip overlay:
+
+- `pasteOnClick` (default ON) — auto-paste the selected item into the previously focused app via synthesized ⌘V keystroke. When OFF, the item is written to the system pasteboard, the overlay closes, focus returns to the previous app, and the user pastes manually with ⌘V.
+- `moveTopOnClick` (default ON) — promote the selected item to the top of the clipboard history list. When OFF, the item stays at its original index.
+
+Both defaults match the current shipping behavior (1.5.0), so existing users see no change after upgrade. The feature mimics Windows clipboard behavior (Win+V) where these knobs are user-controlled.
+
+## Motivation
+
+- Users want the option to paste directly into the focused window on selection (Windows clipboard parity).
+- Users want a stable, chronological history that does not reorder when older items are reused.
+- Both behaviors are already wired in code but are unconditional today; this design exposes them as user preferences.
+
+## Scope
+
+**In scope:**
+- Two persisted Bool settings in `AppSettings`
+- Settings UI in `SettingsView` ("Behavior" GroupBox)
+- Conditional branching in `OverlayWindow.onSelect`
+- Monitor self-write dedupe via `ClipboardMonitor.ignoreCurrentChangeCount()` to prevent re-selecting an item from creating a duplicate history entry
+
+**Out of scope:**
+- Paste-keystroke reliability tweaks (event source, inter-key delays, fallback timeouts)
+- Per-item override of either toggle
+- Keyboard shortcut to toggle paste-on-click at runtime
+
+## Architecture
+
+No new types, services, or modules. The change is additive across existing files:
+
+| File | Change |
+|------|--------|
+| `Models/AppSettings.swift` | Add 2 `@Published` Bool properties + Keys + init defaults |
+| `Views/SettingsView.swift` | New "Behavior" GroupBox with 2 toggles + caption text |
+| `App/OverlayWindow.swift` | `onSelect` closure branches on `AppSettings.shared` flags |
+| `Services/ClipboardMonitor.swift` | Add protocol method + impl: `ignoreCurrentChangeCount()` |
+| `ViewModels/ClipboardListViewModel.swift` | Call `monitor.ignoreCurrentChangeCount()` at end of `setPasteboard(to:)` |
+
+`OverlayWindowController` already has both `hideImmediatelyAndPaste()` and `hideImmediatelyRefocusOnly()`. `AppFocusService` already has both `switchToAppAndPaste(_:)` and `switchToAppOnly(_:)`. No extraction required.
+
+## Data Flow
+
+Select event (click or Enter):
+
+```
+User selects item
+  └─► OverlayWindow.onSelect(item)
+        ├─► viewModel.setPasteboard(to: item)
+        │     ├─► writes to NSPasteboard
+        │     └─► monitor.ignoreCurrentChangeCount()    ← prevents dup capture
+        │
+        ├─► if AppSettings.shared.moveTopOnClick:
+        │     viewModel.promote(item)
+        │
+        └─► if AppSettings.shared.pasteOnClick:
+              autoPastePending = true
+              hideImmediatelyAndPaste()       ← existing path
+            else:
+              autoPastePending = false
+              hideImmediatelyRefocusOnly()    ← existing path
+```
+
+## Components
+
+### `Models/AppSettings.swift`
+
+```swift
+@Published var pasteOnClick: Bool {
+    didSet { UserDefaults.standard.set(pasteOnClick, forKey: Keys.pasteOnClick) }
+}
+@Published var moveTopOnClick: Bool {
+    didSet { UserDefaults.standard.set(moveTopOnClick, forKey: Keys.moveTopOnClick) }
+}
+
+private struct Keys {
+    // ...existing keys
+    static let pasteOnClick = "settings.pasteOnClick"
+    static let moveTopOnClick = "settings.moveTopOnClick"
+}
+
+// In init():
+let initialPasteOnClick = defaults.object(forKey: Keys.pasteOnClick) as? Bool ?? true
+let initialMoveTopOnClick = defaults.object(forKey: Keys.moveTopOnClick) as? Bool ?? true
+self.pasteOnClick = initialPasteOnClick
+self.moveTopOnClick = initialMoveTopOnClick
+```
+
+Defaults via `defaults.object(forKey:) as? Bool ?? true` so an absent key yields `true`. Required: `defaults.bool(forKey:)` returns `false` for absent keys, which would silently flip behavior on first launch.
+
+### `Services/ClipboardMonitor.swift`
+
+```swift
+protocol ClipboardMonitorProtocol {
+    // ...existing
+    func ignoreCurrentChangeCount()
+}
+
+// in ClipboardMonitor:
+func ignoreCurrentChangeCount() {
+    lastChangeCount = NSPasteboard.general.changeCount
+}
+```
+
+### `ViewModels/ClipboardListViewModel.swift`
+
+At the end of `setPasteboard(to:)` — after writing the item to `NSPasteboard.general`:
+
+```swift
+monitor.ignoreCurrentChangeCount()
+```
+
+### `App/OverlayWindow.swift`
+
+`onSelect` closure replaced:
+
+```swift
+let content = ContentView(viewModel: viewModel, onSelect: { [weak self] item in
+    guard let self else { return }
+    self.viewModel.setPasteboard(to: item)
+    if AppSettings.shared.moveTopOnClick {
+        self.viewModel.promote(item)
+    }
+    if AppSettings.shared.pasteOnClick {
+        self.autoPastePending = true
+        self.hideImmediatelyAndPaste()
+    } else {
+        self.autoPastePending = false
+        self.hideImmediatelyRefocusOnly()
+    }
+}, onOpenSettings: { [weak self] in
+    self?.openSettings()
+})
+```
+
+### `Views/SettingsView.swift`
+
+New "Behavior" GroupBox added near existing groups (placement matches existing visual style):
+
+```swift
+GroupBox("Behavior") {
+    VStack(alignment: .leading, spacing: 12) {
+        Toggle("Paste on selection", isOn: $settings.pasteOnClick)
+        Text("Automatically paste to the previous app when selecting an item.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .padding(.leading, 24)
+
+        Toggle("Move item to top on selection", isOn: $settings.moveTopOnClick)
+        Text("When selecting an item, move it to the top of the history list.")
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .padding(.leading, 24)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+}
+```
+
+## Edge Cases
+
+1. **Both toggles OFF** — item written to pasteboard, overlay closes, prev app refocused, history unchanged. User has clipboard ready, manually pastes. Valid state.
+2. **First-launch defaults** — both default ON; behavior identical to current shipping app. No regression.
+3. **Self-write dedupe** — `monitor.ignoreCurrentChangeCount()` called synchronously after pasteboard write. Polling timer's next tick reads `lastChangeCount == NSPasteboard.general.changeCount`, skips emission. Safe.
+4. **Image items + paste OFF** — image written to pasteboard same as text; ⌘V manually works in apps that accept image paste. No code-path difference.
+5. **No previous app to refocus** — `switchToAppOnly` already handles via `cleanup()` + `app.activate`; if no app tracked, the existing no-op path applies.
+6. **Toggle changed while overlay open** — `AppSettings.shared` read at the moment of select; latest value wins. No stale capture.
+
+## Error Handling
+
+No new failure modes. UserDefaults read/write for Bool is infallible. No new I/O, no new async work. Existing paste/refocus error handling unchanged.
+
+## Testing
+
+### Unit tests
+
+1. **`AppSettingsTests`** (new file)
+   - Default values: with cleared UserDefaults, `pasteOnClick == true` and `moveTopOnClick == true`
+   - Persistence: setting each property writes the correct UserDefaults key
+   - Round-trip: write key → re-init `AppSettings` → reads back same value
+
+2. **`ClipboardListViewModelTests`** (extend)
+   - `setPasteboard(to:)` calls `monitor.ignoreCurrentChangeCount()` exactly once
+   - Use mock `ClipboardMonitorProtocol` with a call counter
+
+3. **`ClipboardMonitorTests`** (extend, if file exists; otherwise add)
+   - `ignoreCurrentChangeCount()` updates internal `lastChangeCount` to `NSPasteboard.general.changeCount`
+   - After `ignoreCurrentChangeCount()`, the next `pollPasteboard` (with no external change) emits no item
+
+### Manual QA checklist
+
+| Scenario | Expected |
+|---|---|
+| Both toggles ON, click item | Pastes into prev app, item moves to top |
+| Both toggles ON, Enter key | Same as click |
+| pasteOnClick OFF, move ON, click | Overlay closes, item at top, prev app focused, ⌘V pastes |
+| pasteOnClick ON, move OFF, click | Pastes into prev app, item stays at original index |
+| Both OFF, click | Overlay closes, prev app focused, item at original index, ⌘V pastes |
+| Re-select older item | History contains no duplicate |
+| Toggle settings, restart app | Toggles persist |
+| Toggle while overlay open, then select | Latest value applied |
+
+UI/window/focus behavior is exercised through manual QA; `OverlayWindow.onSelect` branching is not unit-tested directly because it depends on AppKit window state.
+
+## Migration / Rollout
+
+- Existing users: keys absent on first launch after upgrade → defaults applied (both true) → identical behavior to 1.5.0.
+- No data migration required.
+- No version bump required by the design itself; coordinate with release process.
+
+## Open Questions
+
+None.

--- a/project.yml
+++ b/project.yml
@@ -26,8 +26,8 @@ targets:
       PRODUCT_NAME: MaClip
       PRODUCT_BUNDLE_IDENTIFIER: com.jokot.MacClipboard
       INFOPLIST_FILE: App/Info.plist
-      CURRENT_PROJECT_VERSION: 6
-      MARKETING_VERSION: 1.5.0
+      CURRENT_PROJECT_VERSION: 7
+      MARKETING_VERSION: 1.6.0
       DEFINES_MODULE: YES
     scheme:
       testTargets:


### PR DESCRIPTION
## Summary

- Add two persisted user settings controlling selection behavior: `pasteOnClick` (auto-paste into previous app) and `moveTopOnClick` (promote selected item to top of history). Both default ON, matching shipping 1.5.0 behavior — no regression on upgrade. New "Behavior" section in Settings.
- Fix self-write race: `ClipboardListViewModel.setPasteboard(to:)` now calls `monitor.ignoreCurrentChangeCount()` via `defer`, so re-selecting an existing clip never produces a duplicate history entry on any return path (including the image-failure early return).
- Improve auto-paste reliability across target apps: switch synthesized ⌘V to `.combinedSessionState` event source posted to `.cgAnnotatedSessionEventTap` (matches Maccy/Paste); add 50ms gap between keyDown/keyUp and 100ms post-activation delay; bump activation fallback 200ms→500ms.
- Prompt for Accessibility permission at launch via `AXIsProcessTrustedWithOptions(prompt: true)`. Auto-paste silently no-ops without it, and trust is granted per-binary-path, so dev/release builds need separate grants — surfacing the system dialog avoids the silent-failure trap.
- Design spec at `docs/superpowers/specs/2026-05-09-paste-promote-toggles-design.md`; implementation plan at `docs/superpowers/plans/2026-05-09-paste-promote-toggles.md`.

## Test Plan

- [x] `AppSettingsTests` — defaults true when keys absent; persistence round-trip for both toggles
- [x] `ClipboardListViewModelTests` — `setPasteboard(to:)` invokes `monitor.ignoreCurrentChangeCount()` exactly once
- [x] Manual QA matrix (8 scenarios, all pass):
  - Both toggles ON: pastes + promotes (click + Enter)
  - paste OFF, move ON: overlay closes, refocuses prev app, item at top, manual ⌘V works
  - paste ON, move OFF: pastes, item stays at original index
  - Both OFF: closes + refocuses, item stays, manual ⌘V works
  - Re-select older item: no duplicate in history
  - Quit + relaunch: toggle state persists
  - Toggle while overlay open: latest value applied on next select
- [x] Pre-existing `URLUtilsTests` failures unchanged (not introduced by this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)