### PR TITLE
feat: 1.7.1 — OCR provenance, sentinel re-seed, Restore Privacy Defaults

### DIFF
--- a/MacClipboard.xcodeproj/project.pbxproj
+++ b/MacClipboard.xcodeproj/project.pbxproj
@@ -430,7 +430,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -438,7 +438,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jokot.MacClipboard;
 				PRODUCT_NAME = MaClip;
 				SDKROOT = macosx;
@@ -467,7 +467,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 9;
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -475,7 +475,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 1.7.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jokot.MacClipboard;
 				PRODUCT_NAME = MaClip;
 				SDKROOT = macosx;

--- a/Models/AppSettings.swift
+++ b/Models/AppSettings.swift
@@ -73,11 +73,30 @@ final class AppSettings: ObservableObject {
 
     static func makeInitialExcludedBundleIDs() -> [String] {
         let defaults = UserDefaults.standard
-        if let data = defaults.data(forKey: Keys.excludedBundleIDs),
+        let fm = FileManager.default
+        let sentinelURL = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("MaClip", isDirectory: true)
+            .appendingPathComponent(".seeded")
+
+        let sentinelExists = sentinelURL.map { fm.fileExists(atPath: $0.path) } ?? false
+
+        if sentinelExists,
+           let data = defaults.data(forKey: Keys.excludedBundleIDs),
            let decoded = try? JSONDecoder().decode([String].self, from: data) {
-            return decoded   // user has explicit value (possibly empty); never re-seed
+            return decoded
         }
+
+        writeSentinel(at: sentinelURL)
         return defaultSeedExclusions
+    }
+
+    private static func writeSentinel(at url: URL?) {
+        guard let url else { return }
+        let fm = FileManager.default
+        try? fm.createDirectory(at: url.deletingLastPathComponent(),
+                                withIntermediateDirectories: true)
+        try? Data().write(to: url, options: .atomic)
     }
 
     private init() {

--- a/Models/AppSettings.swift
+++ b/Models/AppSettings.swift
@@ -99,6 +99,12 @@ final class AppSettings: ObservableObject {
         try? Data().write(to: url, options: .atomic)
     }
 
+    func restorePrivacyDefaults() {
+        excludedBundleIDs = AppSettings.defaultSeedExclusions
+        skipConcealedItems = false
+        concealedClearTimeout = 300
+    }
+
     private init() {
         let defaults = UserDefaults.standard
         let defaultKeyCode: UInt32 = UInt32(kVK_ANSI_V)

--- a/Models/ClipboardItem.swift
+++ b/Models/ClipboardItem.swift
@@ -33,19 +33,22 @@ struct ClipboardItem: Identifiable {
     let sourceBundleID: String?
     let isConcealed: Bool
     let concealedExpiresAt: Date?
+    let isOCRResult: Bool
 
     init(id: UUID = UUID(),
          date: Date,
          content: ClipboardItemContent,
          sourceBundleID: String? = nil,
          isConcealed: Bool = false,
-         concealedExpiresAt: Date? = nil) {
+         concealedExpiresAt: Date? = nil,
+         isOCRResult: Bool = false) {
         self.id = id
         self.date = date
         self.content = content
         self.sourceBundleID = sourceBundleID
         self.isConcealed = isConcealed
         self.concealedExpiresAt = concealedExpiresAt
+        self.isOCRResult = isOCRResult
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,13 @@ A simple macOS clipboard history app built with SwiftUI.
 
 ## Download
 
-- [Download v1.7.0](https://github.com/jokot/mac-clipboard/releases/tag/v1.7.0)
+- [Download v1.7.1](https://github.com/jokot/mac-clipboard/releases/tag/v1.7.1)
 
-## What's new in 1.7.0
-- Source provenance: every clip now records the bundle ID of the app that copied it, and the overlay shows a 16×16 source-app icon on each row with a hover tooltip. Legacy clips from older versions show a "?" placeholder.
-- `from:` search syntax: filter history by source app — `from:Safari` (display-name substring) or `from:com.apple.Safari` (exact bundle ID). Combines with text tokens: `from:Safari hello`.
-- App exclusion list: copies from apps you exclude are never saved to history. Seeded on first launch with common password managers (1Password 7/8, Bitwarden, Keychain Access, Dashlane, LastPass) plus MaClip itself. Manage via Settings → Privacy → Excluded Apps, or right-click any clip → "Exclude [App]" with an optional retroactive purge of existing clips from that app.
-- Concealed clipboard items: items marked secret by apps like 1Password (via `org.nspasteboard.ConcealedType` / `com.apple.is-sensitive`) are saved with a redacted preview, a lock badge, and a countdown that auto-clears them after a configurable timeout (30 s – 30 min, default 5 min). A toggle in Settings → Privacy lets you skip these items entirely. Expired items are also dropped at app launch.
-- Settings refactored: split the previously-tall settings sheet into four tabs — General / Storage / Privacy / Behavior — with action buttons (Clear All History / About / Close) always visible across tabs.
-- Internals: version 1.7.0, build 8.
+## What's new in 1.7.1
+- OCR / barcode results keep their source app: extracted text or QR clips now inherit the parent image's source-app icon and show a small `text.viewfinder` badge with an "Extracted from image" tooltip, so you can tell the row came from extraction rather than a direct copy.
+- Fresh-install re-seed via a sentinel file: MaClip writes `~/Library/Application Support/MaClip/.seeded` the first time the default exclusion list is applied. Uninstalling with AppCleaner (or otherwise deleting Application Support) now triggers a clean re-seed on next launch — no Terminal commands required.
+- Restore Privacy Defaults: a new red button at the bottom of Settings → Privacy resets the exclusion list to the password-manager seed, turns off "Skip concealed clipboard items", and sets the auto-clear timeout back to 5 minutes. Scoped to the Privacy tab; other settings stay untouched.
+- Internals: version 1.7.1, build 9.
 
 ## Preview
 ![macclip-screenshot.png](https://github.com/user-attachments/assets/4044711e-39c0-4d71-9eea-989855fc919c)

--- a/Services/ClipboardRepository.swift
+++ b/Services/ClipboardRepository.swift
@@ -24,6 +24,7 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
         let sourceBundleID: String?
         let isConcealed: Bool?
         let concealedExpiresAt: Date?
+        let isOCRResult: Bool?
     }
 
     // Serialize all disk operations to avoid race conditions and out-of-order writes
@@ -47,7 +48,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                         id: rec.id, date: rec.date, content: .text(text),
                         sourceBundleID: rec.sourceBundleID,
                         isConcealed: isConcealed,
-                        concealedExpiresAt: rec.concealedExpiresAt
+                        concealedExpiresAt: rec.concealedExpiresAt,
+                        isOCRResult: rec.isOCRResult ?? false
                     ))
                 }
             case "image":
@@ -62,7 +64,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                             id: rec.id, date: rec.date, content: .image(imgContent),
                             sourceBundleID: rec.sourceBundleID,
                             isConcealed: isConcealed,
-                            concealedExpiresAt: rec.concealedExpiresAt
+                            concealedExpiresAt: rec.concealedExpiresAt,
+                            isOCRResult: rec.isOCRResult ?? false
                         ))
                     }
                 }
@@ -72,7 +75,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                         id: rec.id, date: rec.date, content: .url(u),
                         sourceBundleID: rec.sourceBundleID,
                         isConcealed: isConcealed,
-                        concealedExpiresAt: rec.concealedExpiresAt
+                        concealedExpiresAt: rec.concealedExpiresAt,
+                        isOCRResult: rec.isOCRResult ?? false
                     ))
                 }
             default:
@@ -132,7 +136,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                     cachedText: nil, cachedId: nil, cachedBarcode: nil,
                     sourceBundleID: item.sourceBundleID,
                     isConcealed: item.isConcealed,
-                    concealedExpiresAt: item.concealedExpiresAt
+                    concealedExpiresAt: item.concealedExpiresAt,
+                    isOCRResult: item.isOCRResult
                 ))
             case .image(let imgContent):
                 guard let imagesDir else { continue }
@@ -146,7 +151,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                         cachedText: imgContent.cachedText, cachedId: imgContent.cachedId, cachedBarcode: imgContent.cachedBarcode,
                         sourceBundleID: item.sourceBundleID,
                         isConcealed: item.isConcealed,
-                        concealedExpiresAt: item.concealedExpiresAt
+                        concealedExpiresAt: item.concealedExpiresAt,
+                        isOCRResult: item.isOCRResult
                     ))
                 case .memory(let image):
                     let name = item.id.uuidString + ".png"
@@ -167,7 +173,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                             cachedText: imgContent.cachedText, cachedId: imgContent.cachedId, cachedBarcode: imgContent.cachedBarcode,
                             sourceBundleID: item.sourceBundleID,
                             isConcealed: item.isConcealed,
-                            concealedExpiresAt: item.concealedExpiresAt
+                            concealedExpiresAt: item.concealedExpiresAt,
+                            isOCRResult: item.isOCRResult
                         ))
                     }
                 }
@@ -178,7 +185,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                     cachedText: nil, cachedId: nil, cachedBarcode: nil,
                     sourceBundleID: item.sourceBundleID,
                     isConcealed: item.isConcealed,
-                    concealedExpiresAt: item.concealedExpiresAt
+                    concealedExpiresAt: item.concealedExpiresAt,
+                    isOCRResult: item.isOCRResult
                 ))
             }
         }

--- a/Tests/MacClipboardTests/AppSettingsTests.swift
+++ b/Tests/MacClipboardTests/AppSettingsTests.swift
@@ -19,15 +19,28 @@ final class AppSettingsTests: XCTestCase {
         "com.jokot.MacClipboard",
     ]
 
+    private static func sentinelURL() -> URL? {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("MaClip", isDirectory: true)
+            .appendingPathComponent(".seeded")
+    }
+
     override func setUp() {
         super.setUp()
         UserDefaults.standard.removeObject(forKey: pasteKey)
         UserDefaults.standard.removeObject(forKey: moveKey)
+        if let sentinel = Self.sentinelURL() {
+            try? FileManager.default.removeItem(at: sentinel)
+        }
     }
 
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: pasteKey)
         UserDefaults.standard.removeObject(forKey: moveKey)
+        if let sentinel = Self.sentinelURL() {
+            try? FileManager.default.removeItem(at: sentinel)
+        }
         super.tearDown()
     }
 
@@ -37,12 +50,48 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(Set(initial), Self.seedExclusions)
     }
 
-    func test_emptyArrayPersistsAndIsNotReseeded() {
-        let encoded = try! JSONEncoder().encode([String]())
-        UserDefaults.standard.set(encoded, forKey: excludedKey)
+    func test_sentinelAbsentTriggersSeedAndWritesSentinel() throws {
+        let fm = FileManager.default
+        let sentinel = try XCTUnwrap(Self.sentinelURL())
+        try? fm.removeItem(at: sentinel)
+        UserDefaults.standard.removeObject(forKey: excludedKey)
+
+        let initial = AppSettings.makeInitialExcludedBundleIDs()
+        XCTAssertEqual(Set(initial), Self.seedExclusions)
+        XCTAssertTrue(fm.fileExists(atPath: sentinel.path))
+
+        try? fm.removeItem(at: sentinel)
+    }
+
+    func test_sentinelPresentRespectsExplicitEmptyArray() throws {
+        let fm = FileManager.default
+        let sentinel = try XCTUnwrap(Self.sentinelURL())
+        try? fm.createDirectory(at: sentinel.deletingLastPathComponent(),
+                                withIntermediateDirectories: true)
+        try Data().write(to: sentinel)
+        let emptyData = try JSONEncoder().encode([String]())
+        UserDefaults.standard.set(emptyData, forKey: excludedKey)
+
         let initial = AppSettings.makeInitialExcludedBundleIDs()
         XCTAssertEqual(initial, [])
+
         UserDefaults.standard.removeObject(forKey: excludedKey)
+        try? fm.removeItem(at: sentinel)
+    }
+
+    func test_sentinelAbsentButKeyPresentReseedsOnUpgrade() throws {
+        let fm = FileManager.default
+        let sentinel = try XCTUnwrap(Self.sentinelURL())
+        try? fm.removeItem(at: sentinel)
+        let emptyData = try JSONEncoder().encode([String]())
+        UserDefaults.standard.set(emptyData, forKey: excludedKey)
+
+        let initial = AppSettings.makeInitialExcludedBundleIDs()
+        XCTAssertEqual(Set(initial), Self.seedExclusions)
+        XCTAssertTrue(fm.fileExists(atPath: sentinel.path))
+
+        UserDefaults.standard.removeObject(forKey: excludedKey)
+        try? fm.removeItem(at: sentinel)
     }
 
     func test_skipConcealedDefaultFalse() {

--- a/Tests/MacClipboardTests/AppSettingsTests.swift
+++ b/Tests/MacClipboardTests/AppSettingsTests.swift
@@ -150,4 +150,20 @@ final class AppSettingsTests: XCTestCase {
         AppSettings.shared.moveTopOnClick = true
         XCTAssertEqual(UserDefaults.standard.object(forKey: moveKey) as? Bool, true)
     }
+
+    func test_restorePrivacyDefaultsResetsAllThree() {
+        AppSettings.shared.excludedBundleIDs = ["com.foo.bar"]
+        AppSettings.shared.skipConcealedItems = true
+        AppSettings.shared.concealedClearTimeout = 60
+
+        AppSettings.shared.restorePrivacyDefaults()
+
+        XCTAssertEqual(Set(AppSettings.shared.excludedBundleIDs), Self.seedExclusions)
+        XCTAssertFalse(AppSettings.shared.skipConcealedItems)
+        XCTAssertEqual(AppSettings.shared.concealedClearTimeout, 300, accuracy: 0.001)
+
+        UserDefaults.standard.removeObject(forKey: excludedKey)
+        UserDefaults.standard.removeObject(forKey: skipConcealedKey)
+        UserDefaults.standard.removeObject(forKey: concealedTimeoutKey)
+    }
 }

--- a/Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift
+++ b/Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift
@@ -30,6 +30,26 @@ final class ClipboardItemRepositoryTests: XCTestCase {
                        accuracy: 0.001)
     }
 
+    func test_isOCRResultRoundTrips() throws {
+        let item = ClipboardItem(
+            id: UUID(),
+            date: Date(),
+            content: .text("hello"),
+            sourceBundleID: "com.apple.Preview",
+            isConcealed: false,
+            concealedExpiresAt: nil,
+            isOCRResult: true
+        )
+
+        let repo = ClipboardRepository()
+        repo.saveToDisk(items: [item])
+        let loaded = repo.loadFromDisk()
+        defer { repo.clearAllFiles() }
+
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertTrue(loaded[0].isOCRResult)
+    }
+
     func test_legacyJSONDecodesWithDefaults() throws {
         let legacyJSON = """
         [

--- a/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+++ b/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
@@ -234,6 +234,84 @@ final class ClipboardListViewModelTests: XCTestCase {
                        expiry.timeIntervalSince1970,
                        accuracy: 0.001)
     }
+
+    @MainActor
+    func test_imageAppendPreservesIsOCRResult() async {
+        AppSettings.shared.maxItems = 10
+        AppSettings.shared.autoCleanEnabled = false
+
+        let repo = MockRepo()
+        let monitor = MockMonitor()
+        let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+        let img = NSImage(size: NSSize(width: 1, height: 1))
+        let imgContent = ImageContent(source: .memory(img), cachedText: nil, cachedId: nil, cachedBarcode: nil)
+        let item = ClipboardItem(
+            date: Date(),
+            content: .image(imgContent),
+            sourceBundleID: "com.apple.Preview",
+            isOCRResult: true
+        )
+
+        monitor.emit(item)
+        await MainActor.run {
+            XCTAssertEqual(vm.items.count, 1)
+            XCTAssertEqual(vm.items[0].sourceBundleID, "com.apple.Preview")
+            XCTAssertTrue(vm.items[0].isOCRResult)
+        }
+    }
+
+    @MainActor
+    func test_promoteOrInsertResultMarksOCRAndForwardsSource() async {
+        AppSettings.shared.maxItems = 10
+        AppSettings.shared.autoCleanEnabled = false
+
+        let repo = MockRepo()
+        let monitor = MockMonitor()
+        let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+        let result = vm.promoteOrInsertResult(text: "extracted text",
+                                              sourceBundleID: "com.apple.Preview",
+                                              isOCRResult: true)
+        XCTAssertEqual(result.sourceBundleID, "com.apple.Preview")
+        XCTAssertTrue(result.isOCRResult)
+        XCTAssertEqual(vm.items.first?.id, result.id)
+    }
+
+    @MainActor
+    func test_updateImageItemCachePreservesProvenance() async {
+        AppSettings.shared.maxItems = 10
+        AppSettings.shared.autoCleanEnabled = false
+
+        let repo = MockRepo()
+        let monitor = MockMonitor()
+        let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+        let img = NSImage(size: NSSize(width: 1, height: 1))
+        let imgContent = ImageContent(source: .memory(img), cachedText: nil, cachedId: nil, cachedBarcode: nil)
+        let item = ClipboardItem(
+            date: Date(),
+            content: .image(imgContent),
+            sourceBundleID: "com.apple.Preview",
+            isConcealed: false,
+            concealedExpiresAt: nil,
+            isOCRResult: false
+        )
+        monitor.emit(item)
+
+        await MainActor.run {
+            let inserted = vm.items[0]
+            vm.updateImageItemCache(inserted, cachedText: "hello", cachedId: nil, cachedBarcode: nil)
+            let updated = vm.items[0]
+            XCTAssertEqual(updated.sourceBundleID, "com.apple.Preview")
+            XCTAssertFalse(updated.isOCRResult)
+            if case .image(let c) = updated.content {
+                XCTAssertEqual(c.cachedText, "hello")
+            } else {
+                XCTFail("expected image content")
+            }
+        }
+    }
 }
 
 // MARK: - Mocks

--- a/ViewModels/ClipboardListViewModel.swift
+++ b/ViewModels/ClipboardListViewModel.swift
@@ -214,7 +214,8 @@ final class ClipboardListViewModel: ObservableObject {
                     content: .image(newContent),
                     sourceBundleID: item.sourceBundleID,
                     isConcealed: item.isConcealed,
-                    concealedExpiresAt: item.concealedExpiresAt
+                    concealedExpiresAt: item.concealedExpiresAt,
+                    isOCRResult: item.isOCRResult
                 )
             }
         }
@@ -247,7 +248,16 @@ final class ClipboardListViewModel: ObservableObject {
             if let cachedBarcode = cachedBarcode {
                 newContent.cachedBarcode = cachedBarcode
             }
-            items[idx] = ClipboardItem(id: items[idx].id, date: items[idx].date, content: .image(newContent))
+            let existing = items[idx]
+            items[idx] = ClipboardItem(
+                id: existing.id,
+                date: existing.date,
+                content: .image(newContent),
+                sourceBundleID: existing.sourceBundleID,
+                isConcealed: existing.isConcealed,
+                concealedExpiresAt: existing.concealedExpiresAt,
+                isOCRResult: existing.isOCRResult
+            )
             repository.saveToDiskAsync(items: items)
         }
     }
@@ -268,12 +278,23 @@ final class ClipboardListViewModel: ObservableObject {
 
     // Promote existing result or insert a new one; returns the item put on top
     func promoteOrInsertResult(text: String) -> ClipboardItem {
+        return promoteOrInsertResult(text: text, sourceBundleID: nil, isOCRResult: false)
+    }
+
+    func promoteOrInsertResult(text: String,
+                               sourceBundleID: String?,
+                               isOCRResult: Bool) -> ClipboardItem {
         if let url = URLUtils.linkURL(from: text) {
             if let existing = items.first(where: { if case .url(let u) = $0.content { return u == url } else { return false } }) {
                 promote(existing)
                 return existing
             } else {
-                let newItem = ClipboardItem(date: Date(), content: .url(url))
+                let newItem = ClipboardItem(
+                    date: Date(),
+                    content: .url(url),
+                    sourceBundleID: sourceBundleID,
+                    isOCRResult: isOCRResult
+                )
                 insertNewItemAtTop(newItem)
                 return newItem
             }
@@ -282,7 +303,12 @@ final class ClipboardListViewModel: ObservableObject {
                 promote(existing)
                 return existing
             } else {
-                let newItem = ClipboardItem(date: Date(), content: .text(text))
+                let newItem = ClipboardItem(
+                    date: Date(),
+                    content: .text(text),
+                    sourceBundleID: sourceBundleID,
+                    isOCRResult: isOCRResult
+                )
                 insertNewItemAtTop(newItem)
                 return newItem
             }

--- a/Views/Components/ClipboardItemRow.swift
+++ b/Views/Components/ClipboardItemRow.swift
@@ -360,6 +360,8 @@ private struct OCRBadge: View {
         Image(systemName: "text.viewfinder")
             .font(.system(size: 12, weight: .medium))
             .foregroundColor(.secondary)
+            .frame(width: 16, height: 16)
+            .contentShape(Rectangle())
             .help("Extracted from image")
     }
 }

--- a/Views/Components/ClipboardItemRow.swift
+++ b/Views/Components/ClipboardItemRow.swift
@@ -46,6 +46,7 @@ struct ClipboardItemRow: View {
                             bundleID: item.sourceBundleID,
                             isConcealed: item.isConcealed,
                             concealedExpiresAt: item.concealedExpiresAt,
+                            isOCRResult: item.isOCRResult,
                             isHovered: isHovered,
                             onRemove: onRemove)
         case .image(let imgContent):
@@ -54,6 +55,7 @@ struct ClipboardItemRow: View {
                              bundleID: item.sourceBundleID,
                              isConcealed: item.isConcealed,
                              concealedExpiresAt: item.concealedExpiresAt,
+                             isOCRResult: item.isOCRResult,
                              isHovered: isHovered,
                              onRemove: onRemove,
                              onExtractText: onExtractText,
@@ -64,6 +66,7 @@ struct ClipboardItemRow: View {
                            bundleID: item.sourceBundleID,
                            isConcealed: item.isConcealed,
                            concealedExpiresAt: item.concealedExpiresAt,
+                           isOCRResult: item.isOCRResult,
                            isHovered: isHovered,
                            onRemove: onRemove)
         }
@@ -78,6 +81,7 @@ private struct TextItemContent: View {
     let bundleID: String?
     let isConcealed: Bool
     let concealedExpiresAt: Date?
+    let isOCRResult: Bool
     let isHovered: Bool
     let onRemove: () -> Void
 
@@ -104,6 +108,9 @@ private struct TextItemContent: View {
                 }
             }
             Spacer()
+            if isOCRResult {
+                OCRBadge()
+            }
             SourceIconBadge(bundleID: bundleID)
             if isHovered {
                 pillButton(label: "Delete", systemImage: "trash", color: .red,
@@ -120,6 +127,7 @@ private struct ImageItemContent: View {
     let bundleID: String?
     let isConcealed: Bool
     let concealedExpiresAt: Date?
+    let isOCRResult: Bool
     let isHovered: Bool
     let onRemove: () -> Void
     var onExtractText: ((ClipboardItem) -> Void)? = nil
@@ -179,6 +187,9 @@ private struct ImageItemContent: View {
                         ConcealedBadge(expiresAt: concealedExpiresAt)
                     }
                     Spacer()
+                    if isOCRResult {
+                        OCRBadge()
+                    }
                     SourceIconBadge(bundleID: bundleID)
                 }
             }
@@ -223,6 +234,7 @@ private struct URLItemContent: View {
     let bundleID: String?
     let isConcealed: Bool
     let concealedExpiresAt: Date?
+    let isOCRResult: Bool
     let isHovered: Bool
     let onRemove: () -> Void
 
@@ -254,6 +266,9 @@ private struct URLItemContent: View {
                 }
             }
             Spacer()
+            if isOCRResult {
+                OCRBadge()
+            }
             SourceIconBadge(bundleID: bundleID)
             HStack(spacing: 8) {
                 if isHovered {
@@ -337,5 +352,14 @@ private struct ConcealedBadge: View {
             return "\(seconds / 60)m"
         }
         return "\(seconds)s"
+    }
+}
+
+private struct OCRBadge: View {
+    var body: some View {
+        Image(systemName: "text.viewfinder")
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(.secondary)
+            .help("Extracted from image")
     }
 }

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -118,7 +118,11 @@ struct ContentView: View {
                                                 extractionAlert = ExtractionAlert(message: "No text found in the image.")
                                                 return
                                             } else {
-                                                let resultItem = viewModel.promoteOrInsertResult(text: cachedText)
+                                                let resultItem = viewModel.promoteOrInsertResult(
+                                                    text: cachedText,
+                                                    sourceBundleID: item.sourceBundleID,
+                                                    isOCRResult: true
+                                                )
                                                 viewModel.setPasteboard(to: resultItem)
                                                 return
                                             }
@@ -145,7 +149,11 @@ struct ContentView: View {
                                             }
                                             let textId = text
                                             viewModel.updateImageItemCache(item, cachedText: text, cachedId: textId, cachedBarcode: nil)
-                                            let resultItem = viewModel.promoteOrInsertResult(text: text)
+                                            let resultItem = viewModel.promoteOrInsertResult(
+                                                text: text,
+                                                sourceBundleID: item.sourceBundleID,
+                                                isOCRResult: true
+                                            )
                                             viewModel.setPasteboard(to: resultItem)
                                         } catch {
                                             NSSound.beep()
@@ -175,7 +183,11 @@ struct ContentView: View {
                                                 extractionAlert = ExtractionAlert(message: "No barcode detected in the image.")
                                                 return
                                             } else {
-                                                let resultItem = viewModel.promoteOrInsertResult(text: barcode)
+                                                let resultItem = viewModel.promoteOrInsertResult(
+                                                    text: barcode,
+                                                    sourceBundleID: item.sourceBundleID,
+                                                    isOCRResult: true
+                                                )
                                                 viewModel.setPasteboard(to: resultItem)
                                                 return
                                             }
@@ -201,7 +213,11 @@ struct ContentView: View {
                                                 return
                                             }
                                             viewModel.updateImageItemCache(item, cachedText: nil, cachedId: code, cachedBarcode: code)
-                                            let resultItem = viewModel.promoteOrInsertResult(text: code)
+                                            let resultItem = viewModel.promoteOrInsertResult(
+                                                text: code,
+                                                sourceBundleID: item.sourceBundleID,
+                                                isOCRResult: true
+                                            )
                                             viewModel.setPasteboard(to: resultItem)
                                         } catch {
                                             NSSound.beep()

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -257,6 +257,7 @@ private struct PrivacyTab: View {
     @ObservedObject var settings: AppSettings
     @ObservedObject var viewModel: ClipboardListViewModel
     let addApplicationViaPicker: () -> Void
+    @State private var showingRestoreConfirm = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -329,6 +330,21 @@ private struct PrivacyTab: View {
             Text("Items marked secret by apps like 1Password are kept with redacted preview, then removed automatically. Turn the toggle on to skip them entirely.")
                 .font(.caption)
                 .foregroundColor(.secondary)
+
+            Divider().padding(.vertical, 4)
+
+            Button("Restore Privacy Defaults") {
+                showingRestoreConfirm = true
+            }
+            .foregroundColor(.red)
+            .alert("Restore Privacy defaults?", isPresented: $showingRestoreConfirm) {
+                Button("Cancel", role: .cancel) { }
+                Button("Restore", role: .destructive) {
+                    AppSettings.shared.restorePrivacyDefaults()
+                }
+            } message: {
+                Text("This resets the excluded apps list to the default password-manager seed, turns off \"Skip concealed clipboard items\", and sets the auto-clear timeout to 5 minutes.")
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(20)

--- a/docs/superpowers/plans/2026-05-11-1.7.1.md
+++ b/docs/superpowers/plans/2026-05-11-1.7.1.md
@@ -1,0 +1,752 @@
+# MaClip 1.7.1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship MaClip 1.7.1 with three bundled follow-ups from 1.7.0 QA: (1) OCR/QR extraction results inherit the parent image's source app bundle ID and render with an "OCR" badge; (2) sentinel-based fresh-install re-seed so AppCleaner-style uninstalls reset the exclusion list; (3) "Restore Privacy Defaults" button in the Privacy tab.
+
+**Architecture:** All three are additive on top of 1.7.0. New `isOCRResult: Bool` field on `ClipboardItem` (and `PersistRecord`). Provenance forwarding fixed in every VM method that constructs a `ClipboardItem` from an existing one. `AppSettings` gets a sentinel-file check in `makeInitialExcludedBundleIDs()` (using `~/Library/Application Support/MaClip/.seeded`) and a `restorePrivacyDefaults()` method. ContentView's OCR/QR handlers pass `sourceBundleID` from the parent image and mark results as OCR.
+
+**Tech Stack:** Swift, SwiftUI, AppKit, XCTest. Module name: `MaClip`. Build: `xcodebuild -scheme MacClipboard -destination 'platform=macOS' test`.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-11-1.7.1-design.md`
+
+**File map:**
+
+| File | Responsibility |
+|---|---|
+| `Models/ClipboardItem.swift` | Add `isOCRResult: Bool` w/ default false |
+| `Services/ClipboardRepository.swift` | Extend `PersistRecord` w/ `isOCRResult: Bool?`; load+save preserves it |
+| `Models/AppSettings.swift` | Sentinel-file read+write in `makeInitialExcludedBundleIDs()`; `restorePrivacyDefaults()` method |
+| `ViewModels/ClipboardListViewModel.swift` | Forward all provenance + `isOCRResult` in `append`, `updateImageItemCache`, `promoteOrInsertResult`; add overload `promoteOrInsertResult(text:sourceBundleID:isOCRResult:)` |
+| `Views/ContentView.swift` | OCR/QR handlers call the new overload, pass parent image's `sourceBundleID` and `isOCRResult: true` |
+| `Views/Components/ClipboardItemRow.swift` | Render OCR badge when `item.isOCRResult` |
+| `Views/SettingsView.swift` | "Restore Privacy Defaults" button + confirm alert in `PrivacyTab` |
+| `Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift` | Add `isOCRResult` round-trip test |
+| `Tests/MacClipboardTests/AppSettingsTests.swift` | Sentinel + `restorePrivacyDefaults` tests |
+| `Tests/MacClipboardTests/ClipboardListViewModelTests.swift` | OCR forwarding tests |
+| `project.yml` | Version bump 1.7.0→1.7.1, build 8→9 |
+
+---
+
+### Task 1: Add `isOCRResult` field on `ClipboardItem` + `PersistRecord` round-trip
+
+**Files:**
+- Modify: `Models/ClipboardItem.swift`
+- Modify: `Services/ClipboardRepository.swift`
+- Modify: `Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift`
+
+- [ ] **Step 1: Add a failing round-trip test**
+
+Edit `Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift`. Add inside the test class:
+
+```swift
+func test_isOCRResultRoundTrips() throws {
+    let item = ClipboardItem(
+        id: UUID(),
+        date: Date(),
+        content: .text("hello"),
+        sourceBundleID: "com.apple.Preview",
+        isConcealed: false,
+        concealedExpiresAt: nil,
+        isOCRResult: true
+    )
+
+    let repo = ClipboardRepository()
+    repo.saveToDisk(items: [item])
+    let loaded = repo.loadFromDisk()
+    defer { repo.clearAllFiles() }
+
+    XCTAssertEqual(loaded.count, 1)
+    XCTAssertTrue(loaded[0].isOCRResult)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardItemRepositoryTests/test_isOCRResultRoundTrips test
+```
+Expected: FAIL — `Extra argument 'isOCRResult' in call`.
+
+- [ ] **Step 3: Add field to `ClipboardItem`**
+
+Edit `Models/ClipboardItem.swift`. Replace the `struct ClipboardItem` (current 1.7.0 version) with:
+
+```swift
+struct ClipboardItem: Identifiable {
+    let id: UUID
+    let date: Date
+    let content: ClipboardItemContent
+    let sourceBundleID: String?
+    let isConcealed: Bool
+    let concealedExpiresAt: Date?
+    let isOCRResult: Bool
+
+    init(id: UUID = UUID(),
+         date: Date,
+         content: ClipboardItemContent,
+         sourceBundleID: String? = nil,
+         isConcealed: Bool = false,
+         concealedExpiresAt: Date? = nil,
+         isOCRResult: Bool = false) {
+        self.id = id
+        self.date = date
+        self.content = content
+        self.sourceBundleID = sourceBundleID
+        self.isConcealed = isConcealed
+        self.concealedExpiresAt = concealedExpiresAt
+        self.isOCRResult = isOCRResult
+    }
+}
+```
+
+Default `false` so existing call sites compile unchanged.
+
+- [ ] **Step 4: Extend `PersistRecord` and load/save**
+
+Edit `Services/ClipboardRepository.swift`. In the `private struct PersistRecord` declaration, add `let isOCRResult: Bool?` as the last field. In `loadFromDisk()`, in each of the three `case "text" / "image" / "url"` branches, change the `ClipboardItem(...)` call to also pass `isOCRResult: rec.isOCRResult ?? false`.
+
+In `performSave(items:)`, every `PersistRecord(...)` constructor must additionally pass `isOCRResult: item.isOCRResult`. There are 4 sites (text, image-from-file, image-from-memory, url).
+
+Mechanical pattern: at the bottom of every `PersistRecord(...)` argument list, add a trailing `isOCRResult: item.isOCRResult` line. At the bottom of every `ClipboardItem(...)` argument list in `loadFromDisk`, add a trailing `isOCRResult: rec.isOCRResult ?? false` line.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardItemRepositoryTests test
+```
+Expected: PASS (all existing + new test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Models/ClipboardItem.swift Services/ClipboardRepository.swift \
+        Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift
+git commit -m "feat(model): add isOCRResult field to ClipboardItem"
+```
+
+---
+
+### Task 2: Sentinel-file fresh-install re-seed in `AppSettings`
+
+**Files:**
+- Modify: `Models/AppSettings.swift`
+- Modify: `Tests/MacClipboardTests/AppSettingsTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Edit `Tests/MacClipboardTests/AppSettingsTests.swift`. Add inside the test class:
+
+```swift
+private static func sentinelURL() -> URL? {
+    FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        .first?
+        .appendingPathComponent("MaClip", isDirectory: true)
+        .appendingPathComponent(".seeded")
+}
+
+func test_sentinelAbsentTriggersSeedAndWritesSentinel() throws {
+    let fm = FileManager.default
+    let sentinel = try XCTUnwrap(Self.sentinelURL())
+    try? fm.removeItem(at: sentinel)
+    UserDefaults.standard.removeObject(forKey: excludedKey)
+
+    let initial = AppSettings.makeInitialExcludedBundleIDs()
+    XCTAssertEqual(Set(initial), Self.seedExclusions)
+    XCTAssertTrue(fm.fileExists(atPath: sentinel.path))
+
+    try? fm.removeItem(at: sentinel)
+}
+
+func test_sentinelPresentRespectsExplicitEmptyArray() throws {
+    let fm = FileManager.default
+    let sentinel = try XCTUnwrap(Self.sentinelURL())
+    try? fm.createDirectory(at: sentinel.deletingLastPathComponent(),
+                            withIntermediateDirectories: true)
+    try Data().write(to: sentinel)
+    let emptyData = try JSONEncoder().encode([String]())
+    UserDefaults.standard.set(emptyData, forKey: excludedKey)
+
+    let initial = AppSettings.makeInitialExcludedBundleIDs()
+    XCTAssertEqual(initial, [])
+
+    UserDefaults.standard.removeObject(forKey: excludedKey)
+    try? fm.removeItem(at: sentinel)
+}
+
+func test_sentinelAbsentButKeyPresentReseedsOnUpgrade() throws {
+    let fm = FileManager.default
+    let sentinel = try XCTUnwrap(Self.sentinelURL())
+    try? fm.removeItem(at: sentinel)
+    let emptyData = try JSONEncoder().encode([String]())
+    UserDefaults.standard.set(emptyData, forKey: excludedKey)
+
+    let initial = AppSettings.makeInitialExcludedBundleIDs()
+    XCTAssertEqual(Set(initial), Self.seedExclusions)
+    XCTAssertTrue(fm.fileExists(atPath: sentinel.path))
+
+    UserDefaults.standard.removeObject(forKey: excludedKey)
+    try? fm.removeItem(at: sentinel)
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/AppSettingsTests test
+```
+Expected: FAIL — `test_sentinelAbsentTriggersSeedAndWritesSentinel` fails (no sentinel write today); `test_sentinelAbsentButKeyPresentReseedsOnUpgrade` fails (current code respects explicit empty array regardless of sentinel).
+
+- [ ] **Step 3: Update `makeInitialExcludedBundleIDs()`**
+
+Edit `Models/AppSettings.swift`. Replace the existing `static func makeInitialExcludedBundleIDs()` with:
+
+```swift
+static func makeInitialExcludedBundleIDs() -> [String] {
+    let defaults = UserDefaults.standard
+    let fm = FileManager.default
+    let sentinelURL = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        .first?
+        .appendingPathComponent("MaClip", isDirectory: true)
+        .appendingPathComponent(".seeded")
+
+    let sentinelExists = sentinelURL.map { fm.fileExists(atPath: $0.path) } ?? false
+
+    if sentinelExists,
+       let data = defaults.data(forKey: Keys.excludedBundleIDs),
+       let decoded = try? JSONDecoder().decode([String].self, from: data) {
+        return decoded
+    }
+
+    writeSentinel(at: sentinelURL)
+    return defaultSeedExclusions
+}
+
+private static func writeSentinel(at url: URL?) {
+    guard let url else { return }
+    let fm = FileManager.default
+    try? fm.createDirectory(at: url.deletingLastPathComponent(),
+                            withIntermediateDirectories: true)
+    try? Data().write(to: url, options: .atomic)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/AppSettingsTests test
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Models/AppSettings.swift Tests/MacClipboardTests/AppSettingsTests.swift
+git commit -m "feat(settings): sentinel-based fresh-install re-seed for exclusion list"
+```
+
+---
+
+### Task 3: `restorePrivacyDefaults()` method on `AppSettings`
+
+**Files:**
+- Modify: `Models/AppSettings.swift`
+- Modify: `Tests/MacClipboardTests/AppSettingsTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `AppSettingsTests`:
+
+```swift
+func test_restorePrivacyDefaultsResetsAllThree() {
+    AppSettings.shared.excludedBundleIDs = ["com.foo.bar"]
+    AppSettings.shared.skipConcealedItems = true
+    AppSettings.shared.concealedClearTimeout = 60
+
+    AppSettings.shared.restorePrivacyDefaults()
+
+    XCTAssertEqual(Set(AppSettings.shared.excludedBundleIDs), Self.seedExclusions)
+    XCTAssertFalse(AppSettings.shared.skipConcealedItems)
+    XCTAssertEqual(AppSettings.shared.concealedClearTimeout, 300, accuracy: 0.001)
+
+    UserDefaults.standard.removeObject(forKey: excludedKey)
+    UserDefaults.standard.removeObject(forKey: skipConcealedKey)
+    UserDefaults.standard.removeObject(forKey: concealedTimeoutKey)
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/AppSettingsTests/test_restorePrivacyDefaultsResetsAllThree test
+```
+Expected: FAIL — `no member 'restorePrivacyDefaults'`.
+
+- [ ] **Step 3: Add the method**
+
+Edit `Models/AppSettings.swift`. Add inside `final class AppSettings: ObservableObject { … }`:
+
+```swift
+func restorePrivacyDefaults() {
+    excludedBundleIDs = AppSettings.defaultSeedExclusions
+    skipConcealedItems = false
+    concealedClearTimeout = 300
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/AppSettingsTests test
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Models/AppSettings.swift Tests/MacClipboardTests/AppSettingsTests.swift
+git commit -m "feat(settings): add restorePrivacyDefaults() to reset Privacy tab"
+```
+
+---
+
+### Task 4: Forward provenance + `isOCRResult` in `ClipboardListViewModel`
+
+**Files:**
+- Modify: `ViewModels/ClipboardListViewModel.swift`
+- Modify: `Tests/MacClipboardTests/ClipboardListViewModelTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `ClipboardListViewModelTests`:
+
+```swift
+@MainActor
+func test_imageAppendPreservesIsOCRResult() async {
+    AppSettings.shared.maxItems = 10
+    AppSettings.shared.autoCleanEnabled = false
+
+    let repo = MockRepo()
+    let monitor = MockMonitor()
+    let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+    let img = NSImage(size: NSSize(width: 1, height: 1))
+    let imgContent = ImageContent(source: .memory(img), cachedText: nil, cachedId: nil, cachedBarcode: nil)
+    let item = ClipboardItem(
+        date: Date(),
+        content: .image(imgContent),
+        sourceBundleID: "com.apple.Preview",
+        isOCRResult: true
+    )
+
+    monitor.emit(item)
+    await MainActor.run {
+        XCTAssertEqual(vm.items.count, 1)
+        XCTAssertEqual(vm.items[0].sourceBundleID, "com.apple.Preview")
+        XCTAssertTrue(vm.items[0].isOCRResult)
+    }
+}
+
+@MainActor
+func test_promoteOrInsertResultMarksOCRAndForwardsSource() async {
+    AppSettings.shared.maxItems = 10
+    AppSettings.shared.autoCleanEnabled = false
+
+    let repo = MockRepo()
+    let monitor = MockMonitor()
+    let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+    let result = vm.promoteOrInsertResult(text: "extracted text",
+                                          sourceBundleID: "com.apple.Preview",
+                                          isOCRResult: true)
+    XCTAssertEqual(result.sourceBundleID, "com.apple.Preview")
+    XCTAssertTrue(result.isOCRResult)
+    XCTAssertEqual(vm.items.first?.id, result.id)
+}
+
+@MainActor
+func test_updateImageItemCachePreservesProvenance() async {
+    AppSettings.shared.maxItems = 10
+    AppSettings.shared.autoCleanEnabled = false
+
+    let repo = MockRepo()
+    let monitor = MockMonitor()
+    let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+    let img = NSImage(size: NSSize(width: 1, height: 1))
+    let imgContent = ImageContent(source: .memory(img), cachedText: nil, cachedId: nil, cachedBarcode: nil)
+    let item = ClipboardItem(
+        date: Date(),
+        content: .image(imgContent),
+        sourceBundleID: "com.apple.Preview",
+        isConcealed: false,
+        concealedExpiresAt: nil,
+        isOCRResult: false
+    )
+    monitor.emit(item)
+
+    await MainActor.run {
+        let inserted = vm.items[0]
+        vm.updateImageItemCache(inserted, cachedText: "hello", cachedId: nil, cachedBarcode: nil)
+        let updated = vm.items[0]
+        XCTAssertEqual(updated.sourceBundleID, "com.apple.Preview")
+        XCTAssertFalse(updated.isOCRResult)
+        if case .image(let c) = updated.content {
+            XCTAssertEqual(c.cachedText, "hello")
+        } else {
+            XCTFail("expected image content")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify fail**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardListViewModelTests test
+```
+Expected: FAIL — new overload doesn't exist; `updateImageItemCache` drops source; `append` image rewrite drops `isOCRResult`.
+
+- [ ] **Step 3: Patch `append` image-rewrite to forward `isOCRResult`**
+
+In `ViewModels/ClipboardListViewModel.swift`, find the existing image-rewrite path inside `append(_:)`. Update the `ClipboardItem(...)` call to also pass `isOCRResult: item.isOCRResult`:
+
+```swift
+itemToInsert = ClipboardItem(
+    id: item.id,
+    date: item.date,
+    content: .image(newContent),
+    sourceBundleID: item.sourceBundleID,
+    isConcealed: item.isConcealed,
+    concealedExpiresAt: item.concealedExpiresAt,
+    isOCRResult: item.isOCRResult
+)
+```
+
+- [ ] **Step 4: Patch `updateImageItemCache` to forward provenance**
+
+Find the line that rebuilds the image item to update cached values. Replace:
+
+```swift
+items[idx] = ClipboardItem(id: items[idx].id, date: items[idx].date, content: .image(newContent))
+```
+
+with:
+
+```swift
+let existing = items[idx]
+items[idx] = ClipboardItem(
+    id: existing.id,
+    date: existing.date,
+    content: .image(newContent),
+    sourceBundleID: existing.sourceBundleID,
+    isConcealed: existing.isConcealed,
+    concealedExpiresAt: existing.concealedExpiresAt,
+    isOCRResult: existing.isOCRResult
+)
+```
+
+- [ ] **Step 5: Add new `promoteOrInsertResult` overload**
+
+Replace the existing `func promoteOrInsertResult(text: String) -> ClipboardItem` with a wrapper that delegates to the new overload, plus the new overload:
+
+```swift
+func promoteOrInsertResult(text: String) -> ClipboardItem {
+    return promoteOrInsertResult(text: text, sourceBundleID: nil, isOCRResult: false)
+}
+
+func promoteOrInsertResult(text: String,
+                           sourceBundleID: String?,
+                           isOCRResult: Bool) -> ClipboardItem {
+    if let url = URLUtils.linkURL(from: text) {
+        if let existing = items.first(where: { if case .url(let u) = $0.content { return u == url } else { return false } }) {
+            promote(existing)
+            return existing
+        } else {
+            let newItem = ClipboardItem(
+                date: Date(),
+                content: .url(url),
+                sourceBundleID: sourceBundleID,
+                isOCRResult: isOCRResult
+            )
+            insertNewItemAtTop(newItem)
+            return newItem
+        }
+    } else {
+        if let existing = items.first(where: { if case .text(let t) = $0.content { return t == text } else { return false } }) {
+            promote(existing)
+            return existing
+        } else {
+            let newItem = ClipboardItem(
+                date: Date(),
+                content: .text(text),
+                sourceBundleID: sourceBundleID,
+                isOCRResult: isOCRResult
+            )
+            insertNewItemAtTop(newItem)
+            return newItem
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify pass**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardListViewModelTests test
+```
+Expected: PASS — three new tests + all existing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ViewModels/ClipboardListViewModel.swift \
+        Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+git commit -m "feat(viewmodel): forward provenance + isOCRResult in append/cache/promote paths"
+```
+
+---
+
+### Task 5: Wire OCR/QR handlers in `ContentView` to mark results
+
+**Files:**
+- Modify: `Views/ContentView.swift`
+
+UI-only; no automated test.
+
+- [ ] **Step 1: Update OCR/QR call sites**
+
+Find every call to `viewModel.promoteOrInsertResult(text: …)` in `Views/ContentView.swift` (3 sites total, inside `onExtractText` / `onExtractBarcode` closures and possibly the cached-text fast path). Each closure receives a `ClipboardItem` representing the source image — capture its `sourceBundleID` and pass it.
+
+For each site, replace:
+
+```swift
+let resultItem = viewModel.promoteOrInsertResult(text: text)
+```
+
+with:
+
+```swift
+let resultItem = viewModel.promoteOrInsertResult(
+    text: text,
+    sourceBundleID: item.sourceBundleID,
+    isOCRResult: true
+)
+```
+
+(where `item` is the source image clip variable in scope; verify the actual variable name in each closure when you read the file).
+
+- [ ] **Step 2: Build**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build 2>&1 | tail -3
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Views/ContentView.swift
+git commit -m "feat(overlay): mark OCR/QR results as OCR and inherit source bundle id"
+```
+
+---
+
+### Task 6: OCR badge in `ClipboardItemRow`
+
+**Files:**
+- Modify: `Views/Components/ClipboardItemRow.swift`
+
+- [ ] **Step 1: Add `OCRBadge` helper**
+
+Append at end of `Views/Components/ClipboardItemRow.swift` (next to `SourceIconBadge` and `ConcealedBadge`):
+
+```swift
+private struct OCRBadge: View {
+    var body: some View {
+        Image(systemName: "text.viewfinder")
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(.secondary)
+            .help("Extracted from image")
+    }
+}
+```
+
+- [ ] **Step 2: Render the badge in each subview**
+
+Add to each of `TextItemContent`, `URLItemContent`, `ImageItemContent`:
+
+```swift
+let isOCRResult: Bool
+```
+
+In each subview's body, before `SourceIconBadge(bundleID: bundleID)`, conditionally render `OCRBadge()`. Example for `TextItemContent`:
+
+```swift
+Spacer()
+if isOCRResult {
+    OCRBadge()
+}
+SourceIconBadge(bundleID: bundleID)
+if isHovered {
+    pillButton(…)
+}
+```
+
+Same pattern for `URLItemContent` (in the trailing area before the source icon) and `ImageItemContent` (next to the source-icon row).
+
+- [ ] **Step 3: Update the `content` switch in `ClipboardItemRow`**
+
+In `ClipboardItemRow.content`, pass `isOCRResult: item.isOCRResult` to each subview alongside the existing `bundleID`, `isConcealed`, `concealedExpiresAt` parameters.
+
+- [ ] **Step 4: Build**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build 2>&1 | tail -3
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Views/Components/ClipboardItemRow.swift
+git commit -m "feat(row): render OCR badge for extracted result items"
+```
+
+---
+
+### Task 7: "Restore Privacy Defaults" button in `PrivacyTab`
+
+**Files:**
+- Modify: `Views/SettingsView.swift`
+
+- [ ] **Step 1: Add `@State` flag + button + alert**
+
+Inside `PrivacyTab`, add a `@State private var showingRestoreConfirm = false` near the top of the struct.
+
+After the existing timeout picker + caption (at the bottom of the Privacy GroupBox VStack, still inside it), insert:
+
+```swift
+Divider().padding(.vertical, 4)
+
+Button("Restore Privacy Defaults") {
+    showingRestoreConfirm = true
+}
+.foregroundColor(.red)
+.alert("Restore Privacy defaults?", isPresented: $showingRestoreConfirm) {
+    Button("Cancel", role: .cancel) { }
+    Button("Restore", role: .destructive) {
+        AppSettings.shared.restorePrivacyDefaults()
+    }
+} message: {
+    Text("This resets the excluded apps list to the default password-manager seed, turns off \"Skip concealed clipboard items\", and sets the auto-clear timeout to 5 minutes.")
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build 2>&1 | tail -3
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Views/SettingsView.swift
+git commit -m "feat(settings-ui): add Restore Privacy Defaults button to Privacy tab"
+```
+
+---
+
+### Task 8: Manual QA
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build and launch**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' -configuration Debug build && \
+~/Library/Developer/Xcode/DerivedData/MacClipboard-*/Build/Products/Debug/MaClip.app/Contents/MacOS/MaClip
+```
+
+- [ ] **Step 2: Walk the matrix**
+
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | Copy image from Preview, run "Extract text" | OCR result clip appears with Preview's icon AND an "OCR" badge |
+| 2 | OCR result clip → hover the OCR badge | Tooltip "Extracted from image" |
+| 3 | Quit, `rm -rf ~/Library/Application\ Support/MaClip`, relaunch | Settings → Privacy → seed list restored |
+| 4 | Quit, delete only the `.seeded` file but keep `history.json`, relaunch | Seed list restored; history preserved |
+| 5 | Settings → Privacy → empty the exclusion list → quit → relaunch | List stays empty (sentinel still present) |
+| 6 | Settings → Privacy → "Restore Privacy Defaults" → Restore | Exclusion list returns to seed; toggle goes off; timeout returns to 5 min |
+| 7 | Same as #6, Cancel | Nothing changes |
+| 8 | Simulated 1.7.0 upgrade: sentinel absent + empty list in UserDefaults → launch | Seed re-applied (intentional one-time refresh) |
+
+- [ ] **Step 3: Mark complete if all 8 pass**
+
+---
+
+### Task 9: Bump version to 1.7.1 (build 9)
+
+**Files:**
+- Modify: `project.yml`
+- Modify: `MacClipboard.xcodeproj/project.pbxproj` (regenerated)
+
+- [ ] **Step 1: Edit `project.yml`**
+
+```yaml
+      CURRENT_PROJECT_VERSION: 9
+      MARKETING_VERSION: 1.7.1
+```
+
+- [ ] **Step 2: Regenerate**
+
+```bash
+xcodegen generate
+```
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests test 2>&1 | tail -5
+```
+Expected: PASS for our suites.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add project.yml MacClipboard.xcodeproj/project.pbxproj
+git commit -m "chore(version): bump to 1.7.1 (build 9)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| `isOCRResult` field + persistence | 1 |
+| Sentinel-file re-seed logic | 2 |
+| `restorePrivacyDefaults()` method | 3 |
+| Forward provenance + `isOCRResult` through VM | 4 |
+| OCR/QR call sites pass parent source + isOCRResult | 5 |
+| OCR badge in row | 6 |
+| Restore button in Settings | 7 |
+| 8-scenario manual QA | 8 |
+| Version bump | 9 |
+
+**Placeholder scan:** every code-changing step has complete code. No "TBD".
+
+**Type consistency:** `isOCRResult: Bool` used identically across Tasks 1, 4, 5, 6. `restorePrivacyDefaults()` signature consistent in Tasks 3, 7. `promoteOrInsertResult(text:sourceBundleID:isOCRResult:)` signature consistent in Tasks 4, 5.

--- a/docs/superpowers/specs/2026-05-11-1.7.1-design.md
+++ b/docs/superpowers/specs/2026-05-11-1.7.1-design.md
@@ -1,0 +1,221 @@
+# MaClip 1.7.1 — Design
+
+**Date:** 2026-05-11
+**Status:** Approved (pending implementation plan)
+**Target version:** 1.7.1 (build 9)
+**Branch:** feature/1.7.1-followups
+
+## Summary
+
+Three follow-up items from the 1.7.0 QA backlog (`docs/superpowers/specs/2026-05-11-1.7.1-followups.md`), bundled because they all touch the user's first-touch privacy surface:
+
+1. **B1 — OCR result keeps source identity:** OCR / barcode extraction results inherit their parent image's `sourceBundleID` and render with an extra "OCR" badge so the user can tell the row came from extraction, not a direct copy.
+2. **F4 — Sentinel-based fresh-install re-seed:** write `~/Library/Application Support/MaClip/.seeded` the first time the default exclusion list is applied. On every launch, if the sentinel is absent, re-seed. AppCleaner-style uninstalls (which delete Application Support) then trigger a re-seed on the next install without the user having to touch UserDefaults.
+3. **F5 — "Restore Defaults" button (Privacy tab):** one-click reset of the entire Privacy tab — exclusion list returns to seed, "Skip concealed" toggles back to off, timeout resets to 5 min. Scoped to the Privacy tab; other settings untouched.
+
+## Scope
+
+**In scope:**
+- Forward `sourceBundleID` (and the rest of the 1.7.0 provenance fields) through `ClipboardListViewModel.promoteOrInsertResult`, `promoteOrAddItem`, `updateImageItemCache`, and the cached-image rewrite path inside `append(_:)`.
+- Add an `isOCRResult: Bool` (defaulting to false) field on `ClipboardItem` and persist it through `PersistRecord`.
+- Set `isOCRResult = true` whenever OCR / barcode extraction creates or promotes a result item.
+- Render a small "OCR" badge on rows whose `isOCRResult == true`, alongside the existing source icon.
+- Add sentinel-file logic to `AppSettings.makeInitialExcludedBundleIDs()`: read+write `~/Library/Application Support/MaClip/.seeded`. Seed applied iff sentinel absent.
+- Add `AppSettings.restorePrivacyDefaults()` method that re-seeds exclusions, sets `skipConcealedItems = false`, `concealedClearTimeout = 300`.
+- Add "Restore Defaults" button at the bottom of the Privacy tab calling that method.
+- Bump version to 1.7.1 (build 9).
+
+**Out of scope (still on the 1.7.1 follow-ups list, not in this batch):**
+- B2 (frontmost-app race for images) — design decision is "keep current behavior"
+- B3 (per-row concealed timer cadence) — visual polish only
+- F1 (more timer options) — picker entries, easy follow-up
+- F2 (reveal-masked-content eye toggle) — needs separate UX design
+- F3 (never-auto-clear option) — sentinel value design + UI
+
+## Architecture
+
+Additive across existing files; no new types beyond an `isOCRResult` field.
+
+| File | Change |
+|---|---|
+| `Models/ClipboardItem.swift` | Add `isOCRResult: Bool` with default `false`; default init param |
+| `Services/ClipboardRepository.swift` | Extend `PersistRecord` w/ `isOCRResult: Bool?` (optional for legacy decode); preserve through load/save |
+| `Models/AppSettings.swift` | Sentinel file read/write in `makeInitialExcludedBundleIDs()`; new `restorePrivacyDefaults()` method |
+| `ViewModels/ClipboardListViewModel.swift` | Forward `sourceBundleID`, `isConcealed`, `concealedExpiresAt`, `isOCRResult` in `promoteOrInsertResult`, `promoteOrAddItem`, `updateImageItemCache`, and the image-memory→file path of `append(_:)`; new helpers accept an `isOCRResult` flag |
+| `Services/OCRService.swift` (and any callers) | Pass `isOCRResult: true` when constructing the result item |
+| `Views/Components/ClipboardItemRow.swift` | Render a small "OCR" badge (SF Symbol `text.viewfinder` or similar) when `item.isOCRResult` |
+| `Views/SettingsView.swift` | Add "Restore Defaults" button to `PrivacyTab`; calls `AppSettings.shared.restorePrivacyDefaults()` with confirm dialog |
+| `project.yml` | Version bump 1.7.0 → 1.7.1, build 8 → 9 |
+
+`AppMetadata`, `ClipboardMonitor`, `AppFocusService`, `PasteUtility` unchanged.
+
+## Data Model
+
+`ClipboardItem` gains:
+
+```swift
+let isOCRResult: Bool  // true for items produced by OCR/barcode extraction
+```
+
+Init defaults `isOCRResult = false` so existing call sites compile.
+
+`PersistRecord` gains:
+
+```swift
+let isOCRResult: Bool?  // optional so legacy JSON without the key decodes
+```
+
+`loadFromDisk` applies `rec.isOCRResult ?? false`. `performSave` includes the field in every `PersistRecord` construction.
+
+## Sentinel File for Fresh-Install Re-Seed
+
+Location: `~/Library/Application Support/MaClip/.seeded` (zero-byte file; content irrelevant — presence is the signal).
+
+`AppSettings.makeInitialExcludedBundleIDs()` becomes:
+
+```swift
+static func makeInitialExcludedBundleIDs() -> [String] {
+    let defaults = UserDefaults.standard
+    let fm = FileManager.default
+    let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+    let sentinelURL = appSupport?
+        .appendingPathComponent("MaClip", isDirectory: true)
+        .appendingPathComponent(".seeded")
+
+    let sentinelExists = (sentinelURL.flatMap { fm.fileExists(atPath: $0.path) }) ?? false
+
+    if sentinelExists,
+       let data = defaults.data(forKey: Keys.excludedBundleIDs),
+       let decoded = try? JSONDecoder().decode([String].self, from: data) {
+        return decoded   // sentinel present + user has explicit value (possibly empty)
+    }
+
+    // Either sentinel absent (fresh install) OR no UserDefaults value yet.
+    // Apply seed and write sentinel so future launches respect the user's edits.
+    writeSentinel(at: sentinelURL)
+    return defaultSeedExclusions
+}
+
+private static func writeSentinel(at url: URL?) {
+    guard let url else { return }
+    try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                              withIntermediateDirectories: true)
+    try? Data().write(to: url, options: .atomic)
+}
+```
+
+Semantics:
+- **Sentinel absent + key absent (true fresh install):** apply seed, write sentinel
+- **Sentinel absent + key present (1.7.0 user upgrading to 1.7.1):** apply seed (intentional one-time refresh — user gets the new seed list on upgrade), write sentinel
+- **Sentinel present + key absent (manual oddity):** apply seed (no harm), write sentinel
+- **Sentinel present + key present:** use the persisted value, do not touch the sentinel
+
+The 1.7.0 → 1.7.1 upgrade case (sentinel absent, key present) intentionally re-seeds. If a user had explicitly emptied their list in 1.7.0, the upgrade restores the seed. Acceptable trade-off: documented in CHANGELOG; gives the F5 "Restore Defaults" button as the proper way to manage state going forward.
+
+## Restore Privacy Defaults
+
+New method:
+
+```swift
+func restorePrivacyDefaults() {
+    excludedBundleIDs = AppSettings.defaultSeedExclusions
+    skipConcealedItems = false
+    concealedClearTimeout = 300
+}
+```
+
+Setting the `@Published` properties triggers their `didSet` → UserDefaults write, so a relaunch is not needed.
+
+UI: in `PrivacyTab`, below the timeout picker and explanatory caption, add a destructive-style button:
+
+```swift
+Button("Restore Privacy Defaults") {
+    showingRestoreConfirm = true
+}
+.foregroundColor(.red)
+.alert("Restore Privacy defaults?", isPresented: $showingRestoreConfirm) {
+    Button("Cancel", role: .cancel) { }
+    Button("Restore", role: .destructive) {
+        AppSettings.shared.restorePrivacyDefaults()
+    }
+} message: {
+    Text("This resets the excluded apps list to the default password-manager seed, turns off \"Skip concealed clipboard items\", and sets the auto-clear timeout to 5 minutes.")
+}
+```
+
+Scoped only to Privacy tab. Hotkey, Display, Storage, Behavior settings are not touched.
+
+## OCR Result Provenance + Badge
+
+### Item creation
+
+Every code path that constructs a `ClipboardItem` from an existing item must forward all four provenance fields plus `isOCRResult` where appropriate.
+
+Concrete touch points (verified by grep against `ClipboardListViewModel.swift`):
+
+1. `append(_:)` — image memory→file rewrite path (already fixed for the 1.7.0 fields in `f52db1c`; add `isOCRResult: item.isOCRResult`)
+2. `updateImageItemCache(_:cachedText:cachedId:cachedBarcode:)` — rebuilds the image item to update cached values; preserve all provenance + `isOCRResult: items[idx].isOCRResult`
+3. `promoteOrInsertResult(text:)` — creates result items; new variant `promoteOrInsertResult(text:sourceBundleID:)` so OCR can pass the parent image's bundle ID and set `isOCRResult: true`
+4. `promoteOrAddItem(text:cachedId:)` — same treatment
+
+### Row badge
+
+In `ClipboardItemRow`, when `item.isOCRResult == true`, add a small badge next to the source icon. Suggested layout:
+
+```
+[ content preview ............... ] [OCR] [source icon]
+```
+
+`OCR` badge: SF Symbol `text.viewfinder` at 12 pt, secondary color, no border. Tooltip: "Extracted from image".
+
+## Migration
+
+- Existing 1.7.0 JSON files load through `decodeIfPresent` — missing `isOCRResult` defaults to `false`. No special migration required.
+- First launch after 1.7.0 → 1.7.1: sentinel absent → seed re-applied (intentional, see "Sentinel File" above).
+- Existing pre-1.7.0 OCR result items in history will not get `isOCRResult = true` retroactively — they remain marked as non-OCR. Acceptable: those rows render without the badge, no functional difference.
+
+## Edge Cases
+
+1. **Application Support directory not yet writable** (first launch race): sentinel write fails silently; next launch the seed re-applies and sentinel is retried. No harm.
+2. **User deletes Application Support manually** (clearing history): sentinel goes with it; next launch reseeds the exclusion list. Tolerable side effect — "nuke everything" implies "reset everything Privacy too".
+3. **`restorePrivacyDefaults()` invoked while overlay is open:** `@Published` writes propagate via Combine, Privacy tab refreshes immediately. No race.
+4. **OCR result that already exists in history (`findExistingResult` promotes instead of inserting):** when the existing item didn't carry `isOCRResult`, the promote path leaves it false — acceptable; the badge would only appear from then on, on newly-created OCR results.
+
+## Error Handling
+
+No new failure modes. Sentinel file write is best-effort; absence at write time triggers re-seed next launch (idempotent). UserDefaults reads remain infallible.
+
+## Testing
+
+### Unit tests
+
+1. **`ClipboardListViewModelTests`** (extend)
+   - `test_imageAppendPreservesIsOCRResult`: emit an image item with `isOCRResult = true`, verify `vm.items[0].isOCRResult == true`
+   - `test_promoteOrInsertResultPreservesSourceAndMarksOCR`: existing image with `sourceBundleID = "com.apple.Preview"`; call `promoteOrInsertResult(text: "extracted text", sourceBundleID: "com.apple.Preview")`; verify resulting item has `sourceBundleID == "com.apple.Preview"` and `isOCRResult == true`
+   - `test_updateImageItemCachePreservesProvenance`: cache update keeps `sourceBundleID`, `isConcealed`, `isOCRResult`
+
+2. **`ClipboardItemRepositoryTests`** (extend)
+   - `test_isOCRResultRoundTrips`: save item with `isOCRResult = true`, load, assert true
+   - Existing legacy-decode test verifies default `false`
+
+3. **`AppSettingsTests`** (extend)
+   - `test_sentinelAbsentTriggersSeed`: clear UserDefaults key + delete sentinel path → `makeInitialExcludedBundleIDs()` returns seed AND writes sentinel
+   - `test_sentinelPresentRespectsEmptyArray`: write sentinel + JSON-encoded `[]` to UserDefaults → returns `[]`
+   - `test_restorePrivacyDefaultsResetsAllThree`: set non-default values for all three settings, call `restorePrivacyDefaults()`, assert defaults restored
+
+### Manual QA matrix
+
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | Copy image from Preview, run "Extract text" | OCR result clip appears with Preview's icon AND an "OCR" badge |
+| 2 | OCR result clip → hover the OCR badge | Tooltip "Extracted from image" |
+| 3 | Quit, delete `~/Library/Application Support/MaClip/`, relaunch | Settings → Privacy → seed list restored |
+| 4 | Quit, delete only the `.seeded` file but keep `history.json`, relaunch | Seed list restored; history preserved |
+| 5 | Settings → Privacy → empty the exclusion list → quit → relaunch | List stays empty (sentinel still present) |
+| 6 | Settings → Privacy → "Restore Privacy Defaults" → Confirm | Exclusion list returns to seed; toggle goes off; timeout returns to 5 min |
+| 7 | Same as #6, cancel the confirm dialog | Nothing changes |
+| 8 | Upgrade scenario: 1.7.0 user with explicitly-empty list, launches 1.7.1 for first time | Sentinel absent → seed re-applied (intentional one-time refresh) |
+
+## Open Questions
+
+None.

--- a/project.yml
+++ b/project.yml
@@ -26,8 +26,8 @@ targets:
       PRODUCT_NAME: MaClip
       PRODUCT_BUNDLE_IDENTIFIER: com.jokot.MacClipboard
       INFOPLIST_FILE: App/Info.plist
-      CURRENT_PROJECT_VERSION: 8
-      MARKETING_VERSION: 1.7.0
+      CURRENT_PROJECT_VERSION: 9
+      MARKETING_VERSION: 1.7.1
       DEFINES_MODULE: YES
     scheme:
       testTargets:


### PR DESCRIPTION
## Summary

Three bundled follow-ups from the 1.7.0 QA backlog:

- **B1: OCR/QR results keep source identity** — extraction results now inherit `sourceBundleID` from the parent image and render with a small `text.viewfinder` badge ("Extracted from image"). New `isOCRResult: Bool` field on `ClipboardItem` persists through `PersistRecord` and flows through `append`, `updateImageItemCache`, and a new `promoteOrInsertResult(text:sourceBundleID:isOCRResult:)` overload. All four OCR/QR call sites in `ContentView` updated.
- **F4: Fresh-install re-seed via sentinel file** — `~/Library/Application Support/MaClip/.seeded` is written the first time the seed list is applied. On every launch, sentinel absent → seed re-applies regardless of UserDefaults state. AppCleaner-style uninstalls (which delete Application Support) now trigger a clean re-seed on next install. Upgrade users from 1.7.0 get a one-time re-seed.
- **F5: Restore Privacy Defaults** — new red button at the bottom of Settings → Privacy with a destructive confirm alert. Resets the exclusion list to the seed, turns off "Skip concealed clipboard items", and sets the auto-clear timeout back to 5 min. Scope: Privacy tab only.

Plus a minor row fix: OCR badge had an unreliable hover hit area; explicit 16×16 frame + `Rectangle` content shape so `.help()` tooltip fires consistently.

Bumped to 1.7.1 (build 9).

## Test Plan

- [x] Unit: `test_isOCRResultRoundTrips` (persist round-trip)
- [x] Unit: 3 sentinel cases — absent triggers seed + writes sentinel; present respects empty array; absent + key present re-seeds (upgrade path)
- [x] Unit: `test_restorePrivacyDefaultsResetsAllThree`
- [x] Unit: 3 VM tests — image append preserves `isOCRResult`; `promoteOrInsertResult` marks OCR + forwards source; `updateImageItemCache` preserves all provenance
- [x] Manual QA: 7 of 8 scenarios passed (scenario 8 upgrade-sim skipped, already covered by unit test)
- [x] Pre-existing `URLUtilsTests` failures unchanged

## Known 1.7.2 follow-ups (logged during QA)

- Warp screenshot doesn't reach MaClip even with Warp removed from exclusion list — needs pasteboard-UTI inspection; suspect Warp marks copies with a concealed UTI.
- Auto-dismiss overlay after N seconds idle (feature request).
- Pre-existing 1.7.1 backlog (`docs/superpowers/specs/2026-05-11-1.7.1-followups.md`) — B3 (per-row concealed timer cadence), F1 (more timer options), F2 (reveal-masked-content), F3 (never-auto-clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)