### PR TITLE
feat: 1.9.0 — encryption at rest (AES-GCM via Keychain key)

### DIFF
--- a/MacClipboard.xcodeproj/project.pbxproj
+++ b/MacClipboard.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -454,7 +454,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jokot.MacClipboard;
 				PRODUCT_NAME = MaClip;
 				SDKROOT = macosx;
@@ -483,7 +483,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 12;
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -491,7 +491,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jokot.MacClipboard;
 				PRODUCT_NAME = MaClip;
 				SDKROOT = macosx;

--- a/MacClipboard.xcodeproj/project.pbxproj
+++ b/MacClipboard.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		03AC489464E5D2A5DC7208DD /* ClipboardItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C1B3758DFC3B21C63A452 /* ClipboardItemRow.swift */; };
+		0414F7BC1B9B2B06BD0E210F /* HistoryCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79E2300E05E72FCC7AEB159 /* HistoryCryptoTests.swift */; };
 		0EFE4D34B1B4FC0A9B17E1B6 /* TextPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF81986603D19912EF59AD1 /* TextPreview.swift */; };
 		112FD6A5F75656D0F61ACA8C /* InfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E1DDAF695FDA410044FEAC /* InfoViewModel.swift */; };
 		19742895E7A968E617947BA6 /* AppIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2A25C559C9759FD8E4AF7B /* AppIconView.swift */; };
@@ -17,6 +18,7 @@
 		22EC2CF891DA3B0121A16B69 /* AppFocusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668DB323E10EDCA899DDC163 /* AppFocusService.swift */; };
 		267E94E7370774D745DC3C2C /* AppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = EF7344C6550C102B4815F469 /* AppIcon.icns */; };
 		2A79E769A31307E7C4C22F05 /* InfoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA424FD3568939E9C8C9074D /* InfoViewModelTests.swift */; };
+		4CB64154952712185733A483 /* HistoryCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF271F0F519A98A8C1689D1C /* HistoryCrypto.swift */; };
 		571B862018FC471035814617 /* URLUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555F8D49E7C5D1A1174BB492 /* URLUtilsTests.swift */; };
 		59EF8EE29A879D52B3ADE552 /* OCRService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F4194F31C555F3F3166BDA /* OCRService.swift */; };
 		7170F47F267388BAF4517709 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7F2BCE8886027192AD2307 /* Notifications.swift */; };
@@ -88,11 +90,13 @@
 		B2D6D6D9544D32BB060E3211 /* HotKeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKeyService.swift; sourceTree = "<group>"; };
 		C67FC149D427F9DDCBC6AA38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C79D329789FD0A6741C07D77 /* HotkeyUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyUtils.swift; sourceTree = "<group>"; };
+		C79E2300E05E72FCC7AEB159 /* HistoryCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCryptoTests.swift; sourceTree = "<group>"; };
 		D561C754CE8B3377968813CC /* AppMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMetadata.swift; sourceTree = "<group>"; };
 		DA06703AB7DD76075D2895A4 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		DE7CFB463980E025F2453F5F /* TextPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPreviewTests.swift; sourceTree = "<group>"; };
 		E827E59109586E92EF348B3C /* AppSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsTests.swift; sourceTree = "<group>"; };
 		E8F4194F31C555F3F3166BDA /* OCRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRService.swift; sourceTree = "<group>"; };
+		EF271F0F519A98A8C1689D1C /* HistoryCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCrypto.swift; sourceTree = "<group>"; };
 		EF7344C6550C102B4815F469 /* AppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = AppIcon.icns; sourceTree = "<group>"; };
 		F0E228CEA32B7DFEF0889459 /* ContentTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTagsTests.swift; sourceTree = "<group>"; };
 		F7E1DDAF695FDA410044FEAC /* InfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoViewModel.swift; sourceTree = "<group>"; };
@@ -174,6 +178,7 @@
 				69E101E8162A86E28FAB8158 /* ClipboardItemRepositoryTests.swift */,
 				524E4F1E5AC90BE7C9F2F904 /* ClipboardListViewModelTests.swift */,
 				F0E228CEA32B7DFEF0889459 /* ContentTagsTests.swift */,
+				C79E2300E05E72FCC7AEB159 /* HistoryCryptoTests.swift */,
 				AE8D17915B8A6F25E8AA8EDF /* HotkeyUtilsTests.swift */,
 				FA424FD3568939E9C8C9074D /* InfoViewModelTests.swift */,
 				DE7CFB463980E025F2453F5F /* TextPreviewTests.swift */,
@@ -212,6 +217,7 @@
 				668DB323E10EDCA899DDC163 /* AppFocusService.swift */,
 				5FAC45A87AF3BC309EC56D4D /* ClipboardMonitor.swift */,
 				233F1A964D2D27AA2DB09B1B /* ClipboardRepository.swift */,
+				EF271F0F519A98A8C1689D1C /* HistoryCrypto.swift */,
 				B2D6D6D9544D32BB060E3211 /* HotKeyService.swift */,
 				E8F4194F31C555F3F3166BDA /* OCRService.swift */,
 				A4235CBBB175E9BB87DE8791 /* UpdateService.swift */,
@@ -308,6 +314,7 @@
 				F5D648D9827AADB779C058D9 /* ClipboardItemRepositoryTests.swift in Sources */,
 				FF4EFF5E894A57D70AE7B126 /* ClipboardListViewModelTests.swift in Sources */,
 				E30B468F5CA2FC0F21CC9586 /* ContentTagsTests.swift in Sources */,
+				0414F7BC1B9B2B06BD0E210F /* HistoryCryptoTests.swift in Sources */,
 				E25C91356354DBBCF517DBF0 /* HotkeyUtilsTests.swift in Sources */,
 				2A79E769A31307E7C4C22F05 /* InfoViewModelTests.swift in Sources */,
 				87011F9E077DDB68590A1E5D /* TextPreviewTests.swift in Sources */,
@@ -333,6 +340,7 @@
 				B6E3A6C5EE7070AABCCAC0DC /* ContentView.swift in Sources */,
 				1D6DE4479371170E637893FB /* ESCKeyCatcher.swift in Sources */,
 				B7D4E2B42C30142CC9A044ED /* FirstMouseHostingView.swift in Sources */,
+				4CB64154952712185733A483 /* HistoryCrypto.swift in Sources */,
 				7D307A167F9C9108005E211D /* HotKeyService.swift in Sources */,
 				E0C61B17E9A3D544890A8A61 /* HotkeyCapturingView.swift in Sources */,
 				A4C23EAC12FAF4990FA8D75F /* HotkeyUtils.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ A simple macOS clipboard history app built with SwiftUI.
 
 ## Download
 
-- [Download v1.8.0](https://github.com/jokot/mac-clipboard/releases/tag/v1.8.0)
+- [Download v1.9.0](https://github.com/jokot/mac-clipboard/releases/tag/v1.9.0)
 
-## What's new in 1.8.0
-- Smart content tags: MaClip auto-detects what's in each clip (URL, email, phone, JSON, code, hex color, diff) and shows it as the row's leading icon. Detection runs locally at render time — no new fields, no migration. Hex colors tint the palette icon with the actual color.
-- `tag:` search syntax: filter history by detected kind — `tag:code`, `tag:json`, `tag:email`, etc. Combines with the existing `from:` source filter and free-text tokens, e.g. `tag:url from:Safari`, `tag:json hello`. Unknown values yield an empty result.
-- No more duplicate entries: re-copying content already in history promotes the existing item to the top instead of creating a duplicate.
-- Screenshots while the overlay is up: removed the hard-coded self-guard from the monitor; combined with the existing change-count dedupe, screenshots and other clipboard writes that happen while MaClip is focused are now captured. (Default behavior unchanged: MaClip stays in the seeded exclusion list, so users still need to remove it if they want this.)
-- Internals: version 1.8.0, build 11.
+## What's new in 1.9.0
+- Encryption at rest: clipboard history is now stored encrypted on disk via AES-GCM 256. The `history.json` index becomes `history.bin`, and each cached PNG becomes a `.enc` file in `Images/`. The encryption key lives in your macOS Keychain (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly`) and is generated once on first launch.
+- One-time migration: existing 1.8.x users get a transparent upgrade on first 1.9.0 launch — plaintext files are encrypted and removed, a `.encrypted` sentinel is written.
+- Defense against backup leaks: even if `~/Library/Application Support/MaClip/` is copied off the device via Time Machine, AirDrop, or forensic recovery, the data is unreadable without the local Keychain entry.
+- Failure mode: if the Keychain entry is missing or the file is tampered with, MaClip starts with empty history and shows a one-time caption in the About window — the app keeps working, but past clips are unrecoverable on that device.
+- No user-facing toggle, no behavior change. Always on.
+- Internals: version 1.9.0, build 12.
 
 ## Preview
 ![macclip-screenshot.png](https://github.com/user-attachments/assets/4044711e-39c0-4d71-9eea-989855fc919c)

--- a/Services/ClipboardRepository.swift
+++ b/Services/ClipboardRepository.swift
@@ -7,6 +7,7 @@ protocol ClipboardRepositoryProtocol {
     func saveToDiskAsync(items: [ClipboardItem])
     func clearAllFiles()
     func saveImage(_ image: NSImage) -> URL?
+    func readImageData(at encURL: URL) -> Data?
 }
 
 final class ClipboardRepository: ClipboardRepositoryProtocol {
@@ -32,13 +33,25 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
     
 
     func loadFromDisk() -> [ClipboardItem] {
-        guard let url = dataFileURL(), let data = try? Data(contentsOf: url) else { return [] }
+        migrateToEncryptedIfNeeded()
+
+        guard let url = encryptedDataFileURL(),
+              let ciphertext = try? Data(contentsOf: url) else { return [] }
+        let data: Data
+        do {
+            data = try HistoryCrypto.open(ciphertext)
+        } catch {
+            NSLog("[MaClip] failed to decrypt history.bin: \(error)")
+            HistoryDecryptFailure.flag()
+            return []
+        }
+
         let decoder = JSONDecoder()
         guard let records = try? decoder.decode([PersistRecord].self, from: data) else { return [] }
-        
+
         var loaded: [ClipboardItem] = []
         let imagesDir = imagesDirectory()
-        
+
         for rec in records {
             let isConcealed = rec.isConcealed ?? false
             switch rec.type {
@@ -54,9 +67,9 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                 }
             case "image":
                 if let name = rec.imageFilename, let imagesDir {
-                    let imgURL = imagesDir.appendingPathComponent(name)
-                    if FileManager.default.fileExists(atPath: imgURL.path) {
-                        let imgContent = ImageContent(source: .file(imgURL),
+                    let encURL = imagesDir.appendingPathComponent(name)
+                    if FileManager.default.fileExists(atPath: encURL.path) {
+                        let imgContent = ImageContent(source: .file(encURL),
                                                       cachedText: rec.cachedText,
                                                       cachedId: rec.cachedId,
                                                       cachedBarcode: rec.cachedBarcode)
@@ -85,24 +98,63 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
         }
         return loaded
     }
-    
+
     // Helper to persist a single image immediately (used by ViewModel to convert memory->file)
     func saveImage(_ image: NSImage) -> URL? {
         guard let imagesDir = imagesDirectory(),
-              let pngData = image.pngData() else { return nil }
-        
-        // We use a unique ID for the filename.
-        // Optimization: We could hash data to reuse files, but simpler to just write unique for now.
-        let filename = UUID().uuidString + ".png"
+              let pngData = image.pngData(),
+              let ciphertext = try? HistoryCrypto.seal(pngData) else { return nil }
+        let filename = UUID().uuidString + ".enc"
         let fileURL = imagesDir.appendingPathComponent(filename)
-        
         do {
-            try pngData.write(to: fileURL, options: .atomic)
+            try ciphertext.write(to: fileURL, options: .atomic)
             return fileURL
         } catch {
-            print("Failed to save image: \(error)")
+            NSLog("[MaClip] saveImage failed: \(error)")
             return nil
         }
+    }
+
+    func readImageData(at encURL: URL) -> Data? {
+        guard let ciphertext = try? Data(contentsOf: encURL),
+              let plaintext = try? HistoryCrypto.open(ciphertext) else { return nil }
+        return plaintext
+    }
+
+    // MARK: - Migration
+
+    private func migrateToEncryptedIfNeeded() {
+        guard let sentinelURL = encryptedSentinelURL() else { return }
+        let fm = FileManager.default
+        if fm.fileExists(atPath: sentinelURL.path) { return }
+
+        // Migrate history.json → history.bin if a legacy file exists.
+        if let jsonURL = legacyDataFileURL(),
+           fm.fileExists(atPath: jsonURL.path),
+           let plaintext = try? Data(contentsOf: jsonURL) {
+            if let ciphertext = try? HistoryCrypto.seal(plaintext),
+               let binURL = encryptedDataFileURL() {
+                try? ciphertext.write(to: binURL, options: .atomic)
+                try? fm.removeItem(at: jsonURL)
+            } else {
+                NSLog("[MaClip] migrate: failed to encrypt history.json")
+                return
+            }
+        }
+
+        // Migrate each Images/*.png to Images/*.enc.
+        if let imagesDir = imagesDirectory(),
+           let contents = try? fm.contentsOfDirectory(at: imagesDir, includingPropertiesForKeys: nil) {
+            for url in contents where url.pathExtension.lowercased() == "png" {
+                guard let pngData = try? Data(contentsOf: url),
+                      let pngCiphertext = try? HistoryCrypto.seal(pngData) else { continue }
+                let encURL = url.deletingPathExtension().appendingPathExtension("enc")
+                try? pngCiphertext.write(to: encURL, options: .atomic)
+                try? fm.removeItem(at: url)
+            }
+        }
+
+        try? Data().write(to: sentinelURL, options: .atomic)
     }
     
     func saveToDiskAsync(items: [ClipboardItem]) {
@@ -121,7 +173,6 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
 
     // Actual save implementation executed on saveQueue only
     private func performSave(items: [ClipboardItem]) {
-        guard let dataURL = dataFileURL() else { return }
         var records: [PersistRecord] = []
         let imagesDir = imagesDirectory()
         let fm = FileManager.default
@@ -155,14 +206,16 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                         isOCRResult: item.isOCRResult
                     ))
                 case .memory(let image):
-                    let name = item.id.uuidString + ".png"
+                    let name = item.id.uuidString + ".enc"
                     let fileURL = imagesDir.appendingPathComponent(name)
                     if let pngData = image.pngData() {
                         if let existing = savedImageHashes[pngData] {
                             filename = existing
                         } else {
                             if !fm.fileExists(atPath: fileURL.path) {
-                                try? pngData.write(to: fileURL, options: .atomic)
+                                if let pngCiphertext = try? HistoryCrypto.seal(pngData) {
+                                    try? pngCiphertext.write(to: fileURL, options: .atomic)
+                                }
                             }
                             savedImageHashes[pngData] = name
                             filename = name
@@ -193,10 +246,15 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted]
-        if let data = try? encoder.encode(records) {
-            try? data.write(to: dataURL, options: .atomic)
+        guard let plaintext = try? encoder.encode(records) else { return }
+        guard let ciphertext = try? HistoryCrypto.seal(plaintext) else {
+            NSLog("[MaClip] failed to encrypt history; not writing")
+            return
         }
-        
+        if let binURL = encryptedDataFileURL() {
+            try? ciphertext.write(to: binURL, options: .atomic)
+        }
+
         // Cleanup: remove any image files not referenced by current records
         if let imagesDir,
            let contents = try? fm.contentsOfDirectory(at: imagesDir, includingPropertiesForKeys: nil, options: []) {
@@ -213,11 +271,19 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
         // Ensure no save is running while we clear files
         saveQueue.sync {
             let fm = FileManager.default
-            // Remove history.json
-            if let dataURL = dataFileURL(), fm.fileExists(atPath: dataURL.path) {
-                try? fm.removeItem(at: dataURL)
+            // Remove history.bin
+            if let binURL = encryptedDataFileURL(), fm.fileExists(atPath: binURL.path) {
+                try? fm.removeItem(at: binURL)
             }
-            // Remove all images in Images directory
+            // Remove legacy history.json if still present
+            if let jsonURL = legacyDataFileURL(), fm.fileExists(atPath: jsonURL.path) {
+                try? fm.removeItem(at: jsonURL)
+            }
+            // Remove sentinel so subsequent tests start clean
+            if let sentinel = encryptedSentinelURL(), fm.fileExists(atPath: sentinel.path) {
+                try? fm.removeItem(at: sentinel)
+            }
+            // Remove all images in Images directory (.enc and any leftover .png)
             if let imagesDir = imagesDirectory(), fm.fileExists(atPath: imagesDir.path) {
                 if let contents = try? fm.contentsOfDirectory(at: imagesDir, includingPropertiesForKeys: nil, options: []) {
                     for url in contents {
@@ -243,8 +309,16 @@ private extension ClipboardRepository {
         return nil
     }
 
-    func dataFileURL() -> URL? {
+    func encryptedDataFileURL() -> URL? {
+        appSupportDirectory()?.appendingPathComponent("history.bin")
+    }
+
+    func legacyDataFileURL() -> URL? {
         appSupportDirectory()?.appendingPathComponent("history.json")
+    }
+
+    func encryptedSentinelURL() -> URL? {
+        appSupportDirectory()?.appendingPathComponent(".encrypted")
     }
 
     func imagesDirectory() -> URL? {

--- a/Services/HistoryCrypto.swift
+++ b/Services/HistoryCrypto.swift
@@ -1,0 +1,93 @@
+import Foundation
+import CryptoKit
+import Security
+
+enum HistoryCryptoError: Error {
+    case sealFailed
+    case keychainStatus(OSStatus)
+}
+
+enum HistoryCrypto {
+
+    private static let service = "com.jokot.MacClipboard.HistoryEncryptionKey"
+    private static let account = "default"
+
+    // MARK: - Public
+
+    static func seal(_ plaintext: Data) throws -> Data {
+        let k = try key()
+        let sealed = try AES.GCM.seal(plaintext, using: k)
+        guard let combined = sealed.combined else {
+            throw HistoryCryptoError.sealFailed
+        }
+        return combined
+    }
+
+    static func open(_ ciphertext: Data) throws -> Data {
+        let k = try key()
+        let box = try AES.GCM.SealedBox(combined: ciphertext)
+        return try AES.GCM.open(box, using: k)
+    }
+
+    static func key() throws -> SymmetricKey {
+        if let existing = try fetchKey() { return existing }
+        let new = SymmetricKey(size: .bits256)
+        try storeKey(new)
+        return new
+    }
+
+    // MARK: - Keychain
+
+    private static func fetchKey() throws -> SymmetricKey? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data else { return nil }
+            return SymmetricKey(data: data)
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw HistoryCryptoError.keychainStatus(status)
+        }
+    }
+
+    private static func storeKey(_ key: SymmetricKey) throws {
+        let data = key.withUnsafeBytes { Data($0) }
+        let attrs: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            kSecValueData as String: data,
+        ]
+        SecItemDelete(attrs as CFDictionary)
+        let status = SecItemAdd(attrs as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw HistoryCryptoError.keychainStatus(status)
+        }
+    }
+}
+
+/// Static one-launch flag set by the repository when decryption fails.
+enum HistoryDecryptFailure {
+    private static let lock = NSLock()
+    private static var _didFailOnThisLaunch = false
+
+    static var didFailOnThisLaunch: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _didFailOnThisLaunch
+    }
+
+    static func flag() {
+        lock.lock(); defer { lock.unlock() }
+        _didFailOnThisLaunch = true
+    }
+}

--- a/Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift
+++ b/Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift
@@ -50,6 +50,85 @@ final class ClipboardItemRepositoryTests: XCTestCase {
         XCTAssertTrue(loaded[0].isOCRResult)
     }
 
+    func test_encryptedRoundTrip() throws {
+        let item = ClipboardItem(
+            id: UUID(),
+            date: Date(),
+            content: .text("encrypted hello"),
+            sourceBundleID: "com.apple.TextEdit",
+            isConcealed: false,
+            concealedExpiresAt: nil,
+            isOCRResult: false
+        )
+
+        let repo = ClipboardRepository()
+        repo.saveToDisk(items: [item])
+        let loaded = repo.loadFromDisk()
+        defer { repo.clearAllFiles() }
+
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertEqual(loaded[0].sourceBundleID, "com.apple.TextEdit")
+        if case .text(let t) = loaded[0].content {
+            XCTAssertEqual(t, "encrypted hello")
+        } else { XCTFail("expected text") }
+
+        // On-disk file should be history.bin, NOT history.json, and inspecting it must NOT
+        // reveal plaintext.
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first!
+            .appendingPathComponent("MaClip", isDirectory: true)
+        let binURL = appSupport.appendingPathComponent("history.bin")
+        let jsonURL = appSupport.appendingPathComponent("history.json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: binURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: jsonURL.path))
+        let raw = try Data(contentsOf: binURL)
+        XCTAssertFalse(String(data: raw, encoding: .utf8)?.contains("encrypted hello") ?? false,
+                       "plaintext should not be readable in the on-disk binary")
+    }
+
+    func test_legacyJSONMigratesToEncryptedAtFirstLoad() throws {
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first!
+            .appendingPathComponent("MaClip", isDirectory: true)
+        try? FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+
+        try? FileManager.default.removeItem(at: appSupport.appendingPathComponent("history.bin"))
+        try? FileManager.default.removeItem(at: appSupport.appendingPathComponent("history.json"))
+        try? FileManager.default.removeItem(at: appSupport.appendingPathComponent(".encrypted"))
+
+        let legacyJSON = """
+        [
+          {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "date": 770000000,
+            "type": "text",
+            "text": "legacy item",
+            "imageFilename": null,
+            "url": null,
+            "cachedText": null,
+            "cachedId": null,
+            "cachedBarcode": null
+          }
+        ]
+        """.data(using: .utf8)!
+        try legacyJSON.write(to: appSupport.appendingPathComponent("history.json"), options: .atomic)
+
+        let repo = ClipboardRepository()
+        let loaded = repo.loadFromDisk()
+        defer { repo.clearAllFiles() }
+
+        XCTAssertEqual(loaded.count, 1)
+        if case .text(let t) = loaded[0].content {
+            XCTAssertEqual(t, "legacy item")
+        } else { XCTFail("expected text") }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: appSupport.appendingPathComponent("history.json").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appSupport.appendingPathComponent("history.bin").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appSupport.appendingPathComponent(".encrypted").path))
+    }
+
     func test_legacyJSONDecodesWithDefaults() throws {
         let legacyJSON = """
         [

--- a/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+++ b/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
@@ -488,6 +488,9 @@ private final class MockRepo: ClipboardRepositoryProtocol {
         try? Data().write(to: fileURL)
         return fileURL
     }
+    func readImageData(at encURL: URL) -> Data? {
+        return try? Data(contentsOf: encURL)
+    }
 }
 
 private final class MockMonitor: ClipboardMonitorProtocol {

--- a/Tests/MacClipboardTests/HistoryCryptoTests.swift
+++ b/Tests/MacClipboardTests/HistoryCryptoTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+import CryptoKit
+@testable import MaClip
+
+final class HistoryCryptoTests: XCTestCase {
+
+    func test_sealOpenRoundTrip() throws {
+        let plaintext = Data("hello world".utf8)
+        let ciphertext = try HistoryCrypto.seal(plaintext)
+        let recovered = try HistoryCrypto.open(ciphertext)
+        XCTAssertEqual(recovered, plaintext)
+    }
+
+    func test_sealNonceIsRandom() throws {
+        let plaintext = Data("same input".utf8)
+        let a = try HistoryCrypto.seal(plaintext)
+        let b = try HistoryCrypto.seal(plaintext)
+        XCTAssertNotEqual(a, b, "AES-GCM should use a fresh random nonce per seal")
+    }
+
+    func test_tamperedCiphertextFailsAuth() throws {
+        let plaintext = Data("hello".utf8)
+        var ciphertext = try HistoryCrypto.seal(plaintext)
+        ciphertext[ciphertext.count / 2] ^= 0x01
+        XCTAssertThrowsError(try HistoryCrypto.open(ciphertext))
+    }
+
+    func test_keyIsIdempotent() throws {
+        let a = try HistoryCrypto.key()
+        let b = try HistoryCrypto.key()
+        XCTAssertEqual(a.withUnsafeBytes { Data($0) },
+                       b.withUnsafeBytes { Data($0) })
+    }
+}

--- a/ViewModels/ClipboardListViewModel.swift
+++ b/ViewModels/ClipboardListViewModel.swift
@@ -125,7 +125,7 @@ final class ClipboardListViewModel: ObservableObject {
             case .memory(let img):
                 image = img
             case .file(let url):
-                if let data = try? Data(contentsOf: url) {
+                if let data = repository.readImageData(at: url) {
                     image = NSImage(data: data)
                 }
             }
@@ -137,6 +137,12 @@ final class ClipboardListViewModel: ObservableObject {
             _ = pasteboard.writeObjects([url as NSURL])
             pasteboard.setString(url.absoluteString, forType: .string)
         }
+    }
+
+    /// Decrypts image bytes stored at `url` (an `Images/*.enc` ciphertext file).
+    /// Returns the plaintext PNG `Data` suitable for `NSImage(data:)`, or `nil` on failure.
+    func imageData(at url: URL) -> Data? {
+        repository.readImageData(at: url)
     }
 
     func applyMaxItems(_ limit: Int) {

--- a/Views/Components/ClipboardItemRow.swift
+++ b/Views/Components/ClipboardItemRow.swift
@@ -9,6 +9,9 @@ struct ClipboardItemRow: View {
     var onExtractText: ((ClipboardItem) -> Void)? = nil
     var onExtractBarcode: ((ClipboardItem) -> Void)? = nil
     var onExcludeApp: ((String) -> Void)? = nil
+    /// Decrypts image bytes from an `Images/*.enc` URL. Required for `.file` image
+    /// sources after history encryption (1.9.0); without it, the preview stays blank.
+    var loadImageData: ((URL) -> Data?)? = nil
 
     @State private var isHovered: Bool = false
 
@@ -60,7 +63,8 @@ struct ClipboardItemRow: View {
                              isHovered: isHovered,
                              onRemove: onRemove,
                              onExtractText: onExtractText,
-                             onExtractBarcode: onExtractBarcode)
+                             onExtractBarcode: onExtractBarcode,
+                             loadImageData: loadImageData)
         case .url(let url):
             URLItemContent(url: url,
                            date: item.date,
@@ -156,6 +160,7 @@ private struct ImageItemContent: View {
     let onRemove: () -> Void
     var onExtractText: ((ClipboardItem) -> Void)? = nil
     var onExtractBarcode: ((ClipboardItem) -> Void)? = nil
+    var loadImageData: ((URL) -> Data?)? = nil
 
     @State private var loadedImage: NSImage? = nil
     @State private var revealedUntil: Date? = nil
@@ -250,7 +255,7 @@ private struct ImageItemContent: View {
                     .overlay(ProgressView())
                     .task {
                         if case .file(let url) = imgContent.source {
-                            if let data = try? Data(contentsOf: url), let img = NSImage(data: data) {
+                            if let data = loadImageData?(url), let img = NSImage(data: data) {
                                 self.loadedImage = img
                             }
                         }

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -134,10 +134,10 @@ struct ContentView: View {
                                             switch imgContent.source {
                                             case .memory(let img): resolvedImage = img
                                             case .file(let url):
-                                                if let data = try? Data(contentsOf: url) { resolvedImage = NSImage(data: data) }
+                                                if let data = viewModel.imageData(at: url) { resolvedImage = NSImage(data: data) }
                                             }
                                             guard let imageToProcess = resolvedImage else { throw OCRService.OCRError.imageProcessingFailed }
-                                            
+
                                             let text = try await ocrService.extractText(from: imageToProcess)
                                             let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                                             guard !trimmed.isEmpty else {
@@ -199,10 +199,10 @@ struct ContentView: View {
                                             switch imgContent.source {
                                             case .memory(let img): resolvedImage = img
                                             case .file(let url):
-                                                if let data = try? Data(contentsOf: url) { resolvedImage = NSImage(data: data) }
+                                                if let data = viewModel.imageData(at: url) { resolvedImage = NSImage(data: data) }
                                             }
                                             guard let imageToProcess = resolvedImage else { throw OCRService.OCRError.imageProcessingFailed }
-                                            
+
                                             let code = try await ocrService.extractBarcode(from: imageToProcess)
                                             let trimmed = code.trimmingCharacters(in: .whitespacesAndNewlines)
                                             guard !trimmed.isEmpty else {
@@ -239,7 +239,8 @@ struct ContentView: View {
                             },
                             onExcludeApp: { bundleID in
                                 confirmExclude(bundleID: bundleID)
-                            }
+                            },
+                            loadImageData: { url in viewModel.imageData(at: url) }
                         )
                         .id(item.id)
                         Divider()

--- a/Views/InfoView.swift
+++ b/Views/InfoView.swift
@@ -52,6 +52,15 @@ struct InfoView: View {
             }
             .font(.footnote)
             .foregroundColor(.secondary)
+
+            if HistoryDecryptFailure.didFailOnThisLaunch {
+                Text("Couldn't decrypt clipboard history on this launch. A new encryption key will be created when you next copy something. Past clips are unrecoverable on this device.")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+            }
         }
         .padding(24)
         .frame(minWidth: 360)

--- a/docs/superpowers/plans/2026-05-16-1.9.0-encryption.md
+++ b/docs/superpowers/plans/2026-05-16-1.9.0-encryption.md
@@ -1,0 +1,728 @@
+# MaClip 1.9.0 Encryption at Rest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship MaClip 1.9.0 — encrypt the entire local clipboard history (`history.json` → `history.bin`, each PNG → `.enc`) with AES-GCM 256 via CryptoKit. Key in macOS Keychain. One-time migration at first 1.9.0 launch.
+
+**Architecture:** New `Services/HistoryCrypto.swift` exposes `seal(Data) -> Data` / `open(Data) -> Data` plus Keychain-backed `key()`. `ClipboardRepository` is rewritten: load reads `history.bin`, decrypts, decodes JSON; save encodes JSON, encrypts, writes `history.bin`; image save/load route through the same seal/open helpers, file names use `.enc`. Migration logic runs at first launch when the `.encrypted` sentinel is absent: read plaintext, encrypt, delete originals, write sentinel. On decryption failure, repo returns empty + sets a static flag rendered as a caption in the Info window.
+
+**Tech Stack:** Swift, CryptoKit (AES.GCM, SymmetricKey), Security framework (Keychain via SecItem APIs), XCTest. Build: `xcodebuild -scheme MacClipboard -destination 'platform=macOS' test`. XcodeGen — run `xcodegen generate` if new files don't auto-register.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-16-1.9.0-encryption-design.md`
+
+**File map:**
+
+| File | Responsibility |
+|---|---|
+| `Services/HistoryCrypto.swift` (new) | AES-GCM seal/open + Keychain key get-or-create; `HistoryDecryptFailure` flag |
+| `Services/ClipboardRepository.swift` | Load `history.bin`, save encrypted; per-image `.enc`; migration entry; `readImageData(at:)` helper |
+| `ViewModels/ClipboardListViewModel.swift` | Expose `imageData(at:)` that routes through the repository |
+| `Views/InfoView.swift` | Show caption when decryption-failure flag is set |
+| `Views/Components/ClipboardItemRow.swift` and any other consumer of `ImageSource.file(URL)` | Route through `viewModel.imageData(at:)` |
+| `Tests/MacClipboardTests/HistoryCryptoTests.swift` (new) | 4 crypto tests |
+| `Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift` | Migration + encrypted round-trip tests |
+| `project.yml` | Version bump 1.8.0 → 1.9.0, build 11 → 12 |
+
+---
+
+### Task 1: `Services/HistoryCrypto.swift` + tests (TDD)
+
+**Files:**
+- Create: `Services/HistoryCrypto.swift`
+- Create: `Tests/MacClipboardTests/HistoryCryptoTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `Tests/MacClipboardTests/HistoryCryptoTests.swift`:
+
+```swift
+import XCTest
+import CryptoKit
+@testable import MaClip
+
+final class HistoryCryptoTests: XCTestCase {
+
+    func test_sealOpenRoundTrip() throws {
+        let plaintext = Data("hello world".utf8)
+        let ciphertext = try HistoryCrypto.seal(plaintext)
+        let recovered = try HistoryCrypto.open(ciphertext)
+        XCTAssertEqual(recovered, plaintext)
+    }
+
+    func test_sealNonceIsRandom() throws {
+        let plaintext = Data("same input".utf8)
+        let a = try HistoryCrypto.seal(plaintext)
+        let b = try HistoryCrypto.seal(plaintext)
+        XCTAssertNotEqual(a, b, "AES-GCM should use a fresh random nonce per seal")
+    }
+
+    func test_tamperedCiphertextFailsAuth() throws {
+        let plaintext = Data("hello".utf8)
+        var ciphertext = try HistoryCrypto.seal(plaintext)
+        ciphertext[ciphertext.count / 2] ^= 0x01
+        XCTAssertThrowsError(try HistoryCrypto.open(ciphertext))
+    }
+
+    func test_keyIsIdempotent() throws {
+        let a = try HistoryCrypto.key()
+        let b = try HistoryCrypto.key()
+        XCTAssertEqual(a.withUnsafeBytes { Data($0) },
+                       b.withUnsafeBytes { Data($0) })
+    }
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/HistoryCryptoTests test
+```
+Expected: FAIL — `Cannot find 'HistoryCrypto' in scope`.
+
+- [ ] **Step 3: Create `Services/HistoryCrypto.swift`**
+
+```swift
+import Foundation
+import CryptoKit
+import Security
+
+enum HistoryCryptoError: Error {
+    case sealFailed
+    case keychainStatus(OSStatus)
+}
+
+enum HistoryCrypto {
+
+    private static let service = "com.jokot.MacClipboard.HistoryEncryptionKey"
+    private static let account = "default"
+
+    // MARK: - Public
+
+    static func seal(_ plaintext: Data) throws -> Data {
+        let k = try key()
+        let sealed = try AES.GCM.seal(plaintext, using: k)
+        guard let combined = sealed.combined else {
+            throw HistoryCryptoError.sealFailed
+        }
+        return combined
+    }
+
+    static func open(_ ciphertext: Data) throws -> Data {
+        let k = try key()
+        let box = try AES.GCM.SealedBox(combined: ciphertext)
+        return try AES.GCM.open(box, using: k)
+    }
+
+    static func key() throws -> SymmetricKey {
+        if let existing = try fetchKey() { return existing }
+        let new = SymmetricKey(size: .bits256)
+        try storeKey(new)
+        return new
+    }
+
+    // MARK: - Keychain
+
+    private static func fetchKey() throws -> SymmetricKey? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data else { return nil }
+            return SymmetricKey(data: data)
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw HistoryCryptoError.keychainStatus(status)
+        }
+    }
+
+    private static func storeKey(_ key: SymmetricKey) throws {
+        let data = key.withUnsafeBytes { Data($0) }
+        let attrs: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            kSecValueData as String: data,
+        ]
+        SecItemDelete(attrs as CFDictionary)
+        let status = SecItemAdd(attrs as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw HistoryCryptoError.keychainStatus(status)
+        }
+    }
+}
+
+/// Static one-launch flag set by the repository when decryption fails.
+enum HistoryDecryptFailure {
+    private static let lock = NSLock()
+    private static var _didFailOnThisLaunch = false
+
+    static var didFailOnThisLaunch: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _didFailOnThisLaunch
+    }
+
+    static func flag() {
+        lock.lock(); defer { lock.unlock() }
+        _didFailOnThisLaunch = true
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/HistoryCryptoTests test
+```
+Expected: PASS — 4 tests. Run `xcodegen generate` if new file isn't picked up.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Services/HistoryCrypto.swift \
+        Tests/MacClipboardTests/HistoryCryptoTests.swift \
+        MacClipboard.xcodeproj/project.pbxproj
+git commit -m "feat(crypto): AES-GCM seal/open helpers with Keychain key store"
+```
+
+---
+
+### Task 2: Rewrite `ClipboardRepository` for encrypted storage
+
+**Files:**
+- Modify: `Services/ClipboardRepository.swift`
+- Modify: `Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift`
+
+Most invasive task. Read the current `Services/ClipboardRepository.swift` end-to-end before changing anything.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift`:
+
+```swift
+func test_encryptedRoundTrip() throws {
+    let item = ClipboardItem(
+        id: UUID(),
+        date: Date(),
+        content: .text("encrypted hello"),
+        sourceBundleID: "com.apple.TextEdit",
+        isConcealed: false,
+        concealedExpiresAt: nil,
+        isOCRResult: false
+    )
+
+    let repo = ClipboardRepository()
+    repo.saveToDisk(items: [item])
+    let loaded = repo.loadFromDisk()
+    defer { repo.clearAllFiles() }
+
+    XCTAssertEqual(loaded.count, 1)
+    XCTAssertEqual(loaded[0].sourceBundleID, "com.apple.TextEdit")
+    if case .text(let t) = loaded[0].content {
+        XCTAssertEqual(t, "encrypted hello")
+    } else { XCTFail("expected text") }
+
+    // On-disk file should be history.bin, NOT history.json, and inspecting it must NOT
+    // reveal plaintext.
+    let appSupport = FileManager.default
+        .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        .first!
+        .appendingPathComponent("MaClip", isDirectory: true)
+    let binURL = appSupport.appendingPathComponent("history.bin")
+    let jsonURL = appSupport.appendingPathComponent("history.json")
+    XCTAssertTrue(FileManager.default.fileExists(atPath: binURL.path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: jsonURL.path))
+    let raw = try Data(contentsOf: binURL)
+    XCTAssertFalse(String(data: raw, encoding: .utf8)?.contains("encrypted hello") ?? false,
+                   "plaintext should not be readable in the on-disk binary")
+}
+
+func test_legacyJSONMigratesToEncryptedAtFirstLoad() throws {
+    let appSupport = FileManager.default
+        .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        .first!
+        .appendingPathComponent("MaClip", isDirectory: true)
+    try? FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+
+    try? FileManager.default.removeItem(at: appSupport.appendingPathComponent("history.bin"))
+    try? FileManager.default.removeItem(at: appSupport.appendingPathComponent("history.json"))
+    try? FileManager.default.removeItem(at: appSupport.appendingPathComponent(".encrypted"))
+
+    let legacyJSON = """
+    [
+      {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "date": 770000000,
+        "type": "text",
+        "text": "legacy item",
+        "imageFilename": null,
+        "url": null,
+        "cachedText": null,
+        "cachedId": null,
+        "cachedBarcode": null
+      }
+    ]
+    """.data(using: .utf8)!
+    try legacyJSON.write(to: appSupport.appendingPathComponent("history.json"), options: .atomic)
+
+    let repo = ClipboardRepository()
+    let loaded = repo.loadFromDisk()
+    defer { repo.clearAllFiles() }
+
+    XCTAssertEqual(loaded.count, 1)
+    if case .text(let t) = loaded[0].content {
+        XCTAssertEqual(t, "legacy item")
+    } else { XCTFail("expected text") }
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: appSupport.appendingPathComponent("history.json").path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: appSupport.appendingPathComponent("history.bin").path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: appSupport.appendingPathComponent(".encrypted").path))
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardItemRepositoryTests test
+```
+Expected: FAIL — current repo writes plaintext `history.json`.
+
+- [ ] **Step 3: Add helpers to repo private extension**
+
+In `Services/ClipboardRepository.swift`, replace the existing private file-URL helpers with:
+
+```swift
+private extension ClipboardRepository {
+    func appSupportDirectory() -> URL? {
+        let fm = FileManager.default
+        if let url = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            let appDir = url.appendingPathComponent("MaClip", isDirectory: true)
+            if !fm.fileExists(atPath: appDir.path) {
+                try? fm.createDirectory(at: appDir, withIntermediateDirectories: true)
+            }
+            return appDir
+        }
+        return nil
+    }
+
+    func encryptedDataFileURL() -> URL? {
+        appSupportDirectory()?.appendingPathComponent("history.bin")
+    }
+
+    func legacyDataFileURL() -> URL? {
+        appSupportDirectory()?.appendingPathComponent("history.json")
+    }
+
+    func encryptedSentinelURL() -> URL? {
+        appSupportDirectory()?.appendingPathComponent(".encrypted")
+    }
+
+    func imagesDirectory() -> URL? {
+        guard let base = appSupportDirectory() else { return nil }
+        let dir = base.appendingPathComponent("Images", isDirectory: true)
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: dir.path) {
+            try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir
+    }
+}
+```
+
+Remove the old `dataFileURL()` function if it exists — it's replaced by `encryptedDataFileURL()`.
+
+- [ ] **Step 4: Add `migrateToEncryptedIfNeeded()` method on `ClipboardRepository`**
+
+```swift
+private func migrateToEncryptedIfNeeded() {
+    guard let sentinelURL = encryptedSentinelURL() else { return }
+    let fm = FileManager.default
+    if fm.fileExists(atPath: sentinelURL.path) { return }
+
+    // Migrate history.json → history.bin if a legacy file exists.
+    if let jsonURL = legacyDataFileURL(),
+       fm.fileExists(atPath: jsonURL.path),
+       let plaintext = try? Data(contentsOf: jsonURL) {
+        if let ciphertext = try? HistoryCrypto.seal(plaintext),
+           let binURL = encryptedDataFileURL() {
+            try? ciphertext.write(to: binURL, options: .atomic)
+            try? fm.removeItem(at: jsonURL)
+        } else {
+            NSLog("[MaClip] migrate: failed to encrypt history.json")
+            return
+        }
+    }
+
+    // Migrate each Images/*.png to Images/*.enc.
+    if let imagesDir = imagesDirectory(),
+       let contents = try? fm.contentsOfDirectory(at: imagesDir, includingPropertiesForKeys: nil) {
+        for url in contents where url.pathExtension.lowercased() == "png" {
+            guard let pngData = try? Data(contentsOf: url),
+                  let pngCiphertext = try? HistoryCrypto.seal(pngData) else { continue }
+            let encURL = url.deletingPathExtension().appendingPathExtension("enc")
+            try? pngCiphertext.write(to: encURL, options: .atomic)
+            try? fm.removeItem(at: url)
+        }
+    }
+
+    try? Data().write(to: sentinelURL, options: .atomic)
+}
+```
+
+- [ ] **Step 5: Update `loadFromDisk()` to migrate + read encrypted**
+
+Replace the existing `loadFromDisk()` with:
+
+```swift
+func loadFromDisk() -> [ClipboardItem] {
+    migrateToEncryptedIfNeeded()
+
+    guard let url = encryptedDataFileURL(),
+          let ciphertext = try? Data(contentsOf: url) else { return [] }
+    let data: Data
+    do {
+        data = try HistoryCrypto.open(ciphertext)
+    } catch {
+        NSLog("[MaClip] failed to decrypt history.bin: \(error)")
+        HistoryDecryptFailure.flag()
+        return []
+    }
+
+    let decoder = JSONDecoder()
+    guard let records = try? decoder.decode([PersistRecord].self, from: data) else { return [] }
+
+    var loaded: [ClipboardItem] = []
+    let imagesDir = imagesDirectory()
+
+    for rec in records {
+        let isConcealed = rec.isConcealed ?? false
+        switch rec.type {
+        case "text":
+            if let text = rec.text {
+                loaded.append(ClipboardItem(
+                    id: rec.id, date: rec.date, content: .text(text),
+                    sourceBundleID: rec.sourceBundleID,
+                    isConcealed: isConcealed,
+                    concealedExpiresAt: rec.concealedExpiresAt,
+                    isOCRResult: rec.isOCRResult ?? false
+                ))
+            }
+        case "image":
+            if let name = rec.imageFilename, let imagesDir {
+                let encURL = imagesDir.appendingPathComponent(name)
+                if FileManager.default.fileExists(atPath: encURL.path) {
+                    let imgContent = ImageContent(source: .file(encURL),
+                                                  cachedText: rec.cachedText,
+                                                  cachedId: rec.cachedId,
+                                                  cachedBarcode: rec.cachedBarcode)
+                    loaded.append(ClipboardItem(
+                        id: rec.id, date: rec.date, content: .image(imgContent),
+                        sourceBundleID: rec.sourceBundleID,
+                        isConcealed: isConcealed,
+                        concealedExpiresAt: rec.concealedExpiresAt,
+                        isOCRResult: rec.isOCRResult ?? false
+                    ))
+                }
+            }
+        case "url":
+            if let s = rec.url, let u = URL(string: s) {
+                loaded.append(ClipboardItem(
+                    id: rec.id, date: rec.date, content: .url(u),
+                    sourceBundleID: rec.sourceBundleID,
+                    isConcealed: isConcealed,
+                    concealedExpiresAt: rec.concealedExpiresAt,
+                    isOCRResult: rec.isOCRResult ?? false
+                ))
+            }
+        default: continue
+        }
+    }
+    return loaded
+}
+```
+
+- [ ] **Step 6: Update `performSave(items:)` to encrypt**
+
+Find the end of `performSave` where `try? data.write(to: dataURL, options: .atomic)` lives. Replace with:
+
+```swift
+let encoder = JSONEncoder()
+encoder.outputFormatting = [.prettyPrinted]
+guard let plaintext = try? encoder.encode(records) else { return }
+guard let ciphertext = try? HistoryCrypto.seal(plaintext) else {
+    NSLog("[MaClip] failed to encrypt history; not writing")
+    return
+}
+if let binURL = encryptedDataFileURL() {
+    try? ciphertext.write(to: binURL, options: .atomic)
+}
+```
+
+In the image-from-memory branch of `performSave`, change the PNG-write to use `.enc`:
+
+```swift
+case .memory(let image):
+    let name = item.id.uuidString + ".enc"
+    let fileURL = imagesDir.appendingPathComponent(name)
+    if let pngData = image.pngData() {
+        if let existing = savedImageHashes[pngData] {
+            filename = existing
+        } else {
+            if !fm.fileExists(atPath: fileURL.path) {
+                if let pngCiphertext = try? HistoryCrypto.seal(pngData) {
+                    try? pngCiphertext.write(to: fileURL, options: .atomic)
+                }
+            }
+            savedImageHashes[pngData] = name
+            filename = name
+        }
+        records.append(PersistRecord(
+            id: item.id, date: item.date, type: "image",
+            text: nil, imageFilename: filename, url: nil,
+            cachedText: imgContent.cachedText, cachedId: imgContent.cachedId, cachedBarcode: imgContent.cachedBarcode,
+            sourceBundleID: item.sourceBundleID,
+            isConcealed: item.isConcealed,
+            concealedExpiresAt: item.concealedExpiresAt,
+            isOCRResult: item.isOCRResult
+        ))
+    }
+```
+
+`saveImage(_:)` (immediate-save used by VM image rewrite path):
+
+```swift
+func saveImage(_ image: NSImage) -> URL? {
+    guard let imagesDir = imagesDirectory(),
+          let pngData = image.pngData(),
+          let ciphertext = try? HistoryCrypto.seal(pngData) else { return nil }
+    let filename = UUID().uuidString + ".enc"
+    let fileURL = imagesDir.appendingPathComponent(filename)
+    do {
+        try ciphertext.write(to: fileURL, options: .atomic)
+        return fileURL
+    } catch {
+        NSLog("[MaClip] saveImage failed: \(error)")
+        return nil
+    }
+}
+```
+
+- [ ] **Step 7: Add `readImageData(at:)` to protocol + impl**
+
+In `protocol ClipboardRepositoryProtocol`:
+
+```swift
+func readImageData(at encURL: URL) -> Data?
+```
+
+In `final class ClipboardRepository`:
+
+```swift
+func readImageData(at encURL: URL) -> Data? {
+    guard let ciphertext = try? Data(contentsOf: encURL),
+          let plaintext = try? HistoryCrypto.open(ciphertext) else { return nil }
+    return plaintext
+}
+```
+
+In `MockRepo` (in `Tests/MacClipboardTests/ClipboardListViewModelTests.swift`):
+
+```swift
+func readImageData(at encURL: URL) -> Data? {
+    return try? Data(contentsOf: encURL)
+}
+```
+
+- [ ] **Step 8: Run all tests**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests test 2>&1 | tail -5
+```
+Expected: PASS for our suites. (Pre-existing URLUtilsTests failures unchanged.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Services/ClipboardRepository.swift \
+        Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift \
+        Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+git commit -m "feat(repo): encrypt history.bin and Images/*.enc with AES-GCM, one-time migration"
+```
+
+---
+
+### Task 3: Route image consumers through `readImageData(at:)`
+
+**Files:**
+- Modify: `ViewModels/ClipboardListViewModel.swift`
+- Modify: `Views/Components/ClipboardItemRow.swift`
+- Possibly: `Views/ContentView.swift` if it reads image bytes
+
+- [ ] **Step 1: Grep for all read sites**
+
+```bash
+grep -rn "Data(contentsOf:\|NSImage(contentsOf:" Views ViewModels Services Models | grep -v "HistoryCrypto\|Tests"
+```
+
+For each call site that loads image bytes from a `.file(URL)` source, replace with a call into the repository's helper via the view model.
+
+- [ ] **Step 2: Add `imageData(at:)` on `ClipboardListViewModel`**
+
+```swift
+func imageData(at url: URL) -> Data? {
+    repository.readImageData(at: url)
+}
+```
+
+- [ ] **Step 3: Update image rendering in `ClipboardItemRow.swift`**
+
+Find every `NSImage(contentsOf: url)` or `Data(contentsOf: url)` reading from a `.file(URL)` source. Replace with:
+
+```swift
+if let data = viewModel.imageData(at: url),
+   let image = NSImage(data: data) {
+    // render image
+}
+```
+
+If the row doesn't have direct VM access, plumb it through.
+
+- [ ] **Step 4: Build to confirm**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build 2>&1 | tail -3
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Views/Components/ClipboardItemRow.swift \
+        ViewModels/ClipboardListViewModel.swift
+git commit -m "feat(image): route image-file reads through encrypted readImageData helper"
+```
+
+---
+
+### Task 4: Decryption-failed caption in Info window
+
+**Files:**
+- Modify: `Views/InfoView.swift`
+
+- [ ] **Step 1: Render the caption when flag is set**
+
+Add inside the Info view body (near the bottom):
+
+```swift
+if HistoryDecryptFailure.didFailOnThisLaunch {
+    Text("Couldn't decrypt clipboard history on this launch. A new encryption key will be created when you next copy something. Past clips are unrecoverable on this device.")
+        .font(.caption)
+        .foregroundColor(.orange)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build 2>&1 | tail -3
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Views/InfoView.swift
+git commit -m "feat(info): show caption when history decryption fails on launch"
+```
+
+---
+
+### Task 5: Manual QA
+
+Walk the 9-scenario matrix in `docs/superpowers/specs/2026-05-16-1.9.0-encryption-design.md` § "Manual QA matrix". Pay special attention to:
+- Migration on an existing 1.8.0 installation (back up Application Support first)
+- Inspecting `history.bin` and `*.enc` via `cat` — must look like binary garbage
+- Deleting the Keychain entry via Keychain Access.app and relaunching
+
+Mark complete when all 9 pass.
+
+---
+
+### Task 6: Bump version to 1.9.0 (build 12)
+
+**Files:**
+- Modify: `project.yml`
+- Modify: `MacClipboard.xcodeproj/project.pbxproj` (regenerated)
+
+- [ ] **Step 1: Edit `project.yml`**
+
+```yaml
+      CURRENT_PROJECT_VERSION: 12
+      MARKETING_VERSION: 1.9.0
+```
+
+- [ ] **Step 2: Regenerate**
+
+```bash
+xcodegen generate
+```
+
+If xcscheme reverts to `MacClipboard.app`:
+
+```bash
+git checkout -- MacClipboard.xcodeproj/xcshareddata/xcschemes/MacClipboard.xcscheme
+```
+
+- [ ] **Step 3: Tests**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests test 2>&1 | tail -5
+```
+Expected: PASS for our suites.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add project.yml MacClipboard.xcodeproj/project.pbxproj
+git commit -m "chore(version): bump to 1.9.0 (build 12)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| `HistoryCrypto.seal/open/key` | 1 |
+| Keychain key storage | 1 |
+| `HistoryDecryptFailure` flag | 1 |
+| `history.bin` save + load | 2 |
+| `Images/*.enc` save + load | 2 |
+| Migration sentinel + one-time migration | 2 |
+| `readImageData(at:)` helper | 2 |
+| Image-consumer routing via VM | 3 |
+| Info-window caption on decrypt failure | 4 |
+| Manual QA | 5 |
+| Version bump | 6 |
+
+**Placeholder scan:** Every code-changing step has complete code. Task 3 includes a grep instruction with the explicit replacement pattern.
+
+**Type consistency:** `HistoryCrypto` API (`seal`, `open`, `key`) consistent across Tasks 1 and 2. `HistoryDecryptFailure.flag()` / `.didFailOnThisLaunch` consistent across Tasks 1, 2, 4. `readImageData(at:)` signature consistent across Tasks 2 and 3.

--- a/docs/superpowers/specs/2026-05-16-1.9.0-encryption-design.md
+++ b/docs/superpowers/specs/2026-05-16-1.9.0-encryption-design.md
@@ -1,0 +1,279 @@
+# MaClip 1.9.0 — Encryption at Rest — Design
+
+**Date:** 2026-05-16
+**Status:** Approved (pending implementation plan)
+**Target version:** 1.9.0 (build 12)
+**Branch:** feature/1.9.0-encryption
+
+## Summary
+
+Encrypt all locally-persisted clipboard data at rest:
+
+- `~/Library/Application Support/MaClip/history.json` → AES-GCM 256 ciphertext, single binary file (`history.bin`).
+- Each PNG image file in `~/Library/Application Support/MaClip/Images/<uuid>.png` → AES-GCM 256 ciphertext (`<uuid>.enc`).
+- Encryption key stored in the macOS Keychain (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly`), generated once on first launch.
+
+Always-on, no user-facing toggle. One-time forced migration at first 1.9.0 launch. If decryption fails (key missing, file corrupted), MaClip starts with empty history and shows a one-time warning.
+
+## Wedge
+
+Privacy is the foundation of the wedge. App-level encryption is marginal on top of FileVault for the modern single-user Mac case but defends against: Time Machine backups (unencrypted by default), multi-user Macs, offline-disk access, and forensic data recovery. Pairs naturally with the existing exclusion / concealed-handling story.
+
+## Scope
+
+**In scope:**
+- New `Services/HistoryCrypto.swift` — AES-GCM helpers, key fetch/create via Keychain.
+- `ClipboardRepository` rewrites — read encrypted blobs, decrypt on load, encrypt on save.
+- One-time migration at first 1.9.0 launch with sentinel absent: read existing plaintext `history.json` + `Images/*.png`, encrypt + write as `history.bin` + `Images/*.enc`, delete plaintext originals, write migration sentinel.
+- Migration sentinel: `~/Library/Application Support/MaClip/.encrypted` (zero-byte marker; presence = "encryption migration done").
+- Failure handling: corrupted or unreadable encrypted store → start with empty history, post a one-time notification banner in the Info window.
+- Unit tests for crypto helpers (round-trip, key creation idempotence, tampered-ciphertext rejection).
+- Bump version to 1.9.0 (build 12).
+
+**Out of scope:**
+- TouchID / Secure Enclave biometric unlock (1.9.x).
+- User-visible "encryption is on" indicator beyond the version bump itself.
+- iCloud Keychain sync of the encryption key (key stays per-device — multi-Mac users start fresh per device).
+- Settings toggle to disable encryption.
+- Re-keying / key rotation UI.
+
+## Architecture
+
+| File | Responsibility |
+|---|---|
+| `Services/HistoryCrypto.swift` (new) | AES-GCM seal/open via CryptoKit; Keychain key get-or-create via Security framework |
+| `Services/ClipboardRepository.swift` | Read `.bin` instead of `.json`; encrypt `Data` before write; per-image `.enc` read/write; migration entry-point invoked from `loadFromDisk` |
+| `Models/ClipboardItem.swift` | Unchanged |
+| `Models/AppSettings.swift` | Unchanged |
+| `ViewModels/ClipboardListViewModel.swift` | Unchanged externally; surfaces migration-failed flag via a new `@Published var encryptedHistoryFailedToLoad: Bool` |
+| `Views/InfoView.swift` (or wherever info / About lives) | Show a small warning row if the failure flag is set on this launch |
+| `Tests/MacClipboardTests/HistoryCryptoTests.swift` (new) | Round-trip, tampering rejection, key idempotence |
+| `Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift` | Existing tests retargeted to round-trip via the encrypted path; legacy decode test extended to cover the migration |
+| `project.yml` | Version bump 1.8.0 → 1.9.0, build 11 → 12 |
+
+## Crypto
+
+**Cipher:** AES-GCM-256 via `CryptoKit.AES.GCM`. Authenticated; built-in 16-byte tag prevents undetected tampering.
+
+**Key:** 32 random bytes (`SymmetricKey(size: .bits256)`), stored in macOS Keychain as a generic password item:
+
+- service: `com.jokot.MacClipboard.HistoryEncryptionKey`
+- account: `default`
+- accessible: `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
+- value: raw 32 bytes of `SymmetricKey.rawRepresentation`
+
+Key fetch logic:
+
+```swift
+@MainActor
+enum HistoryCrypto {
+    static func key() throws -> SymmetricKey {
+        if let existing = try fetchKey() { return existing }
+        let new = SymmetricKey(size: .bits256)
+        try storeKey(new)
+        return new
+    }
+
+    private static func fetchKey() throws -> SymmetricKey? { … }
+    private static func storeKey(_ key: SymmetricKey) throws { … }
+}
+```
+
+**Seal / Open helpers:**
+
+```swift
+static func seal(_ plaintext: Data) throws -> Data {
+    let key = try key()
+    let sealed = try AES.GCM.seal(plaintext, using: key)
+    guard let combined = sealed.combined else {
+        throw HistoryCryptoError.sealFailed
+    }
+    return combined
+}
+
+static func open(_ ciphertext: Data) throws -> Data {
+    let key = try key()
+    let box = try AES.GCM.SealedBox(combined: ciphertext)
+    return try AES.GCM.open(box, using: key)
+}
+```
+
+`SealedBox.combined` produces a single contiguous `Data` (12-byte nonce + ciphertext + 16-byte tag). Same format used for both `history.bin` and `Images/<uuid>.enc`.
+
+## File Layout
+
+Before 1.9.0:
+```
+~/Library/Application Support/MaClip/
+  history.json
+  Images/
+    <uuid>.png
+    ...
+  .seeded                       (from 1.7.1)
+```
+
+After 1.9.0 first launch:
+```
+~/Library/Application Support/MaClip/
+  history.bin                   (encrypted JSON)
+  Images/
+    <uuid>.enc                  (encrypted PNG)
+    ...
+  .seeded
+  .encrypted                    (migration sentinel)
+```
+
+`history.json` and `Images/*.png` are **deleted** after successful migration.
+
+## Migration
+
+Entry point: `ClipboardRepository.init()` or first `loadFromDisk()` call (whichever the existing repo uses). Idempotent:
+
+```
+let sentinelExists = fileExists(at: appSupport/.encrypted)
+if sentinelExists {
+    return  // already migrated
+}
+
+guard let jsonURL = appSupport/history.json, fileExists(at: jsonURL) else {
+    // No legacy file — fresh install. Mark as encrypted-from-start.
+    writeSentinel()
+    return
+}
+
+do {
+    let plaintext = try Data(contentsOf: jsonURL)
+    let ciphertext = try HistoryCrypto.seal(plaintext)
+    try ciphertext.write(to: appSupport/history.bin, options: .atomic)
+
+    // Migrate every PNG in Images/
+    for pngURL in pngFilesInImagesDir {
+        let pngData = try Data(contentsOf: pngURL)
+        let pngCiphertext = try HistoryCrypto.seal(pngData)
+        let encURL = pngURL.deletingPathExtension().appendingPathExtension("enc")
+        try pngCiphertext.write(to: encURL, options: .atomic)
+        try FileManager.default.removeItem(at: pngURL)
+    }
+
+    try FileManager.default.removeItem(at: jsonURL)
+    writeSentinel()
+} catch {
+    NSLog("[MaClip] encryption migration failed: \(error)")
+}
+```
+
+**Recovery on partial migration:**
+- If `history.bin` exists but `history.json` also exists, `loadFromDisk` prefers `history.bin` (trust the encrypted version). On the next launch, migration sees sentinel absent and retries — idempotent for the `.png` → `.enc` step (skips already-converted files).
+
+## Load Path
+
+`ClipboardRepository.loadFromDisk()`:
+
+```swift
+guard let url = encryptedDataFileURL(),
+      let ciphertext = try? Data(contentsOf: url) else {
+    return []
+}
+guard let data = try? HistoryCrypto.open(ciphertext) else {
+    NSLog("[MaClip] failed to decrypt history.bin")
+    HistoryDecryptFailure.flag()
+    return []
+}
+let decoder = JSONDecoder()
+guard let records = try? decoder.decode([PersistRecord].self, from: data) else { return [] }
+…
+```
+
+Image files: when iterating records to construct `ClipboardItem`s, change the image-file path from `<uuid>.png` to `<uuid>.enc`. The actual decrypt happens lazily when a view needs the bytes — extract a helper:
+
+```swift
+extension ClipboardRepository {
+    /// Reads an encrypted PNG file and returns its decrypted bytes. Returns nil on failure.
+    func readImageData(at encURL: URL) -> Data? {
+        guard let ciphertext = try? Data(contentsOf: encURL),
+              let plaintext = try? HistoryCrypto.open(ciphertext) else { return nil }
+        return plaintext
+    }
+}
+```
+
+`ImageItemContent` and any other consumer that today loads `NSImage(contentsOf:)` from the `.file(URL)` source must route through this helper. The `ImageSource.file(URL)` enum case is repurposed to mean "encrypted file at this URL" — consumers must use `readImageData(at:)` rather than `Data(contentsOf:)` directly.
+
+## Save Path
+
+`ClipboardRepository.performSave(items:)`:
+
+```swift
+let encoder = JSONEncoder()
+encoder.outputFormatting = [.prettyPrinted]
+guard let plaintext = try? encoder.encode(records) else { return }
+guard let ciphertext = try? HistoryCrypto.seal(plaintext) else {
+    NSLog("[MaClip] failed to encrypt history; not writing")
+    return
+}
+try? ciphertext.write(to: encryptedDataFileURL()!, options: .atomic)
+```
+
+Image save (currently `pngData.write(...)`): replace with a wrap-then-write pattern:
+
+```swift
+if let pngData = image.pngData(),
+   let ciphertext = try? HistoryCrypto.seal(pngData) {
+    let encURL = imagesDir.appendingPathComponent(item.id.uuidString + ".enc")
+    try? ciphertext.write(to: encURL, options: .atomic)
+    filename = encURL.lastPathComponent
+}
+```
+
+`PersistRecord.imageFilename` now stores `<uuid>.enc`.
+
+## Failure Mode
+
+Decryption fails when:
+- Keychain entry was deleted by the user (`Keychain Access.app`).
+- Disk file was tampered with (AES-GCM auth tag mismatch).
+- Different Mac restored a Time Machine backup containing `history.bin` (key didn't move with it).
+
+On failure:
+- `loadFromDisk` returns `[]` (empty history).
+- A static flag is set: `HistoryDecryptFailure.didFailOnThisLaunch = true`.
+- The Info / About window renders a small caption: `"Couldn't decrypt clipboard history on this launch. A new encryption key will be created when you next copy something. Past clips are unrecoverable on this device."`
+- On the next save, a fresh `history.bin` is written using the (possibly new) key, replacing the unreadable file.
+
+User can clear the corrupted state manually by deleting Application Support; on next launch a fresh key + empty history start.
+
+## Tests
+
+### Unit — `HistoryCryptoTests`
+
+1. `test_sealOpenRoundTrip` — `open(seal(x)) == x`.
+2. `test_sealNonceIsRandom` — calling `seal` twice with the same plaintext returns different ciphertexts.
+3. `test_tamperedCiphertextFailsAuth` — flipping one byte in ciphertext causes `open` to throw.
+4. `test_keyIsIdempotent` — `try HistoryCrypto.key()` returns the same key across two calls within a process.
+
+### Unit — `ClipboardItemRepositoryTests`
+
+5. Round-trip text item through encrypted save + load.
+6. Round-trip image item: write encrypted, read decrypted bytes match original PNG.
+7. Migration: pre-populate `history.json` + plaintext PNG; run migration; verify `history.bin` + `.enc` exist, originals removed, loaded items match.
+8. Sentinel present + missing `history.bin` → empty history, no migration retry.
+
+Existing tests for `ClipboardItem` and `PersistRecord` continue to pass — they're independent of the persistence layer.
+
+### Manual QA matrix
+
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | Fresh install (no Application Support) → launch 1.9.0 | App starts; no history; `.encrypted` sentinel + empty `history.bin` (or no file until first save) |
+| 2 | Upgrade from 1.8.0 with existing `history.json` + PNGs | First launch migrates: `history.bin` appears, `.enc` files replace PNGs, originals deleted, sentinel written. All clips visible after migration. |
+| 3 | Copy text + image after migration; quit + relaunch | Both clips restored, image previews render correctly. |
+| 4 | Delete the Keychain entry via Keychain Access.app, relaunch | Empty history; Info window shows the decryption-failed caption; first new copy succeeds and seeds a new key |
+| 5 | Tamper with `history.bin` (e.g. `echo 'x' >> history.bin`), relaunch | Same as #4: empty history + caption |
+| 6 | Delete `.encrypted` sentinel only, relaunch | Migration is retried (no-op if no plaintext) and sentinel rewritten |
+| 7 | Inspect `history.bin` via `cat` | Binary garbage; no plaintext visible |
+| 8 | Inspect any `Images/*.enc` via `cat` | Binary garbage; no PNG magic bytes visible |
+| 9 | Time Machine restore on a different Mac, launch | Migration sentinel present (from source), but key missing → decryption fails on first load → empty history + caption; subsequent saves seed a new local key |
+
+## Open Questions
+
+None.

--- a/project.yml
+++ b/project.yml
@@ -26,8 +26,8 @@ targets:
       PRODUCT_NAME: MaClip
       PRODUCT_BUNDLE_IDENTIFIER: com.jokot.MacClipboard
       INFOPLIST_FILE: App/Info.plist
-      CURRENT_PROJECT_VERSION: 11
-      MARKETING_VERSION: 1.8.0
+      CURRENT_PROJECT_VERSION: 12
+      MARKETING_VERSION: 1.9.0
       DEFINES_MODULE: YES
     scheme:
       testTargets:


### PR DESCRIPTION
## Summary

Clipboard history is now encrypted on disk:

- `~/Library/Application Support/MaClip/history.json` → `history.bin` (AES-GCM 256 ciphertext, single contiguous nonce+ciphertext+tag).
- Each cached PNG in `Images/<uuid>.png` → `Images/<uuid>.enc`.
- Encryption key generated once via `SymmetricKey(size: .bits256)` and stored in the macOS Keychain (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly`) under service `com.jokot.MacClipboard.HistoryEncryptionKey`.
- New `Services/HistoryCrypto.swift` exposes `seal(_:)`, `open(_:)`, and `key()`.
- `ClipboardRepository` rewritten end-to-end: load reads + decrypts `history.bin`, save encodes JSON then encrypts; image save writes encrypted `.enc`; new `readImageData(at:)` decrypts per-image bytes on demand. All consumer sites (`setPasteboard`, `ImageItemContent`, OCR extraction) route through it.
- One-time forced migration at first 1.9.0 launch when `.encrypted` sentinel is absent: read plaintext `history.json` + `Images/*.png`, encrypt, write `history.bin` + `Images/*.enc`, delete originals, write sentinel.
- Failure mode: if the Keychain entry is deleted or `history.bin` is tampered with, `loadFromDisk` returns `[]` and `HistoryDecryptFailure.flag()` is set. The About / Info window renders a one-time orange caption telling the user past clips on this device are unrecoverable; the next save seeds a fresh key.
- Always on, no user toggle. Privacy is the wedge; making it negotiable defeats the point.

Bumped to 1.9.0 (build 12).

## Test Plan

- [x] `HistoryCryptoTests` — seal/open round-trip, random-nonce, tampered ciphertext fails auth, key idempotent (4 tests)
- [x] `ClipboardItemRepositoryTests` — encrypted text round-trip verifies `history.bin` is binary garbage with no plaintext leak; legacy-JSON-migrates-on-first-load verifies sentinel + binary outcome
- [x] Pre-existing tests (`ClipboardListViewModelTests`, `AppSettingsTests`, `ContentTagsTests`) untouched
- [x] Manual QA:
  - S1: post-migration directory shows `history.bin` + `.encrypted` sentinel + no `history.json`
  - S2: `xxd history.bin` shows binary garbage; no JSON keys or content text leak
  - S3: text + image clips render and paste correctly after migration
- [x] Pre-existing `URLUtilsTests` failures unrelated to this branch (still 2)

## Caveats

- Multi-Mac users get a fresh key per device. History from one Mac isn't readable on another (intentional — we don't sync the Keychain entry).
- App-level encryption is marginal on a FileVault-on machine but defends Time Machine backups, multi-user Macs, offline-disk access, forensic recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)