### PR TITLE
feat: 1.10.0 — file & folder clips with unified context menu

### DIFF
--- a/MacClipboard.xcodeproj/project.pbxproj
+++ b/MacClipboard.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -454,7 +454,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jokot.MacClipboard;
 				PRODUCT_NAME = MaClip;
 				SDKROOT = macosx;
@@ -483,7 +483,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -491,7 +491,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jokot.MacClipboard;
 				PRODUCT_NAME = MaClip;
 				SDKROOT = macosx;

--- a/Models/ClipboardItem.swift
+++ b/Models/ClipboardItem.swift
@@ -24,6 +24,7 @@ enum ClipboardItemContent {
     case text(String)
     case image(ImageContent)
     case url(URL)
+    case file([URL])
 }
 
 struct ClipboardItem: Identifiable {
@@ -71,6 +72,8 @@ extension ClipboardItem: Equatable {
             }
         case let (.url(a), .url(b)):
             return a.absoluteString == b.absoluteString
+        case let (.file(a), .file(b)):
+            return a == b
         default:
             return false
         }

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ A simple macOS clipboard history app built with SwiftUI.
 
 ## Download
 
-- [Download v1.9.0](https://github.com/jokot/mac-clipboard/releases/tag/v1.9.0)
+- [Download v1.10.0](https://github.com/jokot/mac-clipboard/releases/tag/v1.10.0)
 
-## What's new in 1.9.0
-- Encryption at rest: clipboard history is now stored encrypted on disk via AES-GCM 256. The `history.json` index becomes `history.bin`, and each cached PNG becomes a `.enc` file in `Images/`. The encryption key lives in your macOS Keychain (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly`) and is generated once on first launch.
-- One-time migration: existing 1.8.x users get a transparent upgrade on first 1.9.0 launch — plaintext files are encrypted and removed, a `.encrypted` sentinel is written.
-- Defense against backup leaks: even if `~/Library/Application Support/MaClip/` is copied off the device via Time Machine, AirDrop, or forensic recovery, the data is unreadable without the local Keychain entry.
-- Failure mode: if the Keychain entry is missing or the file is tampered with, MaClip starts with empty history and shows a one-time caption in the About window — the app keeps working, but past clips are unrecoverable on that device.
-- No user-facing toggle, no behavior change. Always on.
-- Internals: version 1.9.0, build 12.
+## What's new in 1.10.0
+- File and folder clips: ⌘C on files or folders in Finder (or anywhere that writes file URLs to the pasteboard) is now captured as a new clip kind. The clip stores URLs only — no file contents are copied. Multi-selection becomes one clip showing `FirstFile +N more`.
+- Row UI for file clips shows the file's actual icon (via `NSWorkspace.icon(forFile:)`) plus its name and parent directory. Stale clips (file deleted after capture) automatically swap to a `?` ghost icon.
+- Right-click a file clip → unified menu with `Open`, `Reveal in Finder`, `Copy Path`, then the existing `Exclude "<App>"`. Same menu shape on all clip types now.
+- Copy Path writes the file paths as text to the pasteboard and adds a new text clip with the original file clip's source attribution (typically Finder), instead of attributing it to whichever app happens to be frontmost.
+- New `tag:file` search filter; free-text search also matches file paths.
+- Internals: version 1.10.0, build 13.
 
 ## Preview
 ![macclip-screenshot.png](https://github.com/user-attachments/assets/4044711e-39c0-4d71-9eea-989855fc919c)

--- a/Services/ClipboardMonitor.swift
+++ b/Services/ClipboardMonitor.swift
@@ -65,6 +65,16 @@ final class ClipboardMonitor: ClipboardMonitorProtocol {
             ? (timeout == -1 ? Date.distantFuture : Date().addingTimeInterval(timeout))
             : nil
 
+        if let urls = readFileURLs(from: pb), !urls.isEmpty {
+            subject.send(ClipboardItem(
+                date: Date(), content: .file(urls),
+                sourceBundleID: sourceBundleID,
+                isConcealed: isConcealed,
+                concealedExpiresAt: expiry
+            ))
+            return
+        }
+
         // Read content (image > URL > text) — same priority as before.
         if let image = readImage(from: pb) {
             let imgContent = ImageContent(source: .memory(image),
@@ -114,6 +124,13 @@ final class ClipboardMonitor: ClipboardMonitorProtocol {
             if let str = item.string(forType: .string) { return str }
         }
         return nil
+    }
+
+    private func readFileURLs(from pb: NSPasteboard) -> [URL]? {
+        let opts: [NSPasteboard.ReadingOptionKey: Any] = [.urlReadingFileURLsOnly: true]
+        guard let objects = pb.readObjects(forClasses: [NSURL.self], options: opts) as? [URL],
+              !objects.isEmpty else { return nil }
+        return objects
     }
 
     private func readURL(from pasteboard: NSPasteboard) -> URL? {

--- a/Services/ClipboardRepository.swift
+++ b/Services/ClipboardRepository.swift
@@ -14,7 +14,7 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
     private struct PersistRecord: Codable {
         let id: UUID
         let date: Date
-        let type: String // "text", "image", or "url"
+        let type: String // "text", "image", "url", or "file"
         let text: String?
         let imageFilename: String?
         let url: String?
@@ -26,6 +26,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
         let isConcealed: Bool?
         let concealedExpiresAt: Date?
         let isOCRResult: Bool?
+        // Added in 1.10.0; optional so legacy JSON without this key still decodes.
+        let filePaths: [String]?
     }
 
     // Serialize all disk operations to avoid race conditions and out-of-order writes
@@ -86,6 +88,17 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                 if let s = rec.url, let u = URL(string: s) {
                     loaded.append(ClipboardItem(
                         id: rec.id, date: rec.date, content: .url(u),
+                        sourceBundleID: rec.sourceBundleID,
+                        isConcealed: isConcealed,
+                        concealedExpiresAt: rec.concealedExpiresAt,
+                        isOCRResult: rec.isOCRResult ?? false
+                    ))
+                }
+            case "file":
+                if let paths = rec.filePaths {
+                    let urls = paths.map { URL(fileURLWithPath: $0) }
+                    loaded.append(ClipboardItem(
+                        id: rec.id, date: rec.date, content: .file(urls),
                         sourceBundleID: rec.sourceBundleID,
                         isConcealed: isConcealed,
                         concealedExpiresAt: rec.concealedExpiresAt,
@@ -188,7 +201,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                     sourceBundleID: item.sourceBundleID,
                     isConcealed: item.isConcealed,
                     concealedExpiresAt: item.concealedExpiresAt,
-                    isOCRResult: item.isOCRResult
+                    isOCRResult: item.isOCRResult,
+                    filePaths: nil
                 ))
             case .image(let imgContent):
                 guard let imagesDir else { continue }
@@ -203,7 +217,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                         sourceBundleID: item.sourceBundleID,
                         isConcealed: item.isConcealed,
                         concealedExpiresAt: item.concealedExpiresAt,
-                        isOCRResult: item.isOCRResult
+                        isOCRResult: item.isOCRResult,
+                        filePaths: nil
                     ))
                 case .memory(let image):
                     let name = item.id.uuidString + ".enc"
@@ -227,7 +242,8 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                             sourceBundleID: item.sourceBundleID,
                             isConcealed: item.isConcealed,
                             concealedExpiresAt: item.concealedExpiresAt,
-                            isOCRResult: item.isOCRResult
+                            isOCRResult: item.isOCRResult,
+                            filePaths: nil
                         ))
                     }
                 }
@@ -239,7 +255,19 @@ final class ClipboardRepository: ClipboardRepositoryProtocol {
                     sourceBundleID: item.sourceBundleID,
                     isConcealed: item.isConcealed,
                     concealedExpiresAt: item.concealedExpiresAt,
-                    isOCRResult: item.isOCRResult
+                    isOCRResult: item.isOCRResult,
+                    filePaths: nil
+                ))
+            case .file(let urls):
+                records.append(PersistRecord(
+                    id: item.id, date: item.date, type: "file",
+                    text: nil, imageFilename: nil, url: nil,
+                    cachedText: nil, cachedId: nil, cachedBarcode: nil,
+                    sourceBundleID: item.sourceBundleID,
+                    isConcealed: item.isConcealed,
+                    concealedExpiresAt: item.concealedExpiresAt,
+                    isOCRResult: item.isOCRResult,
+                    filePaths: urls.map(\.path)
                 ))
             }
         }

--- a/Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift
+++ b/Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift
@@ -129,6 +129,40 @@ final class ClipboardItemRepositoryTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: appSupport.appendingPathComponent(".encrypted").path))
     }
 
+    func test_fileClipRoundTrips() throws {
+        let url1 = URL(fileURLWithPath: "/tmp/maclip-test-1.txt")
+        let url2 = URL(fileURLWithPath: "/tmp/maclip-test-2.txt")
+        try Data().write(to: url1)
+        try Data().write(to: url2)
+        defer {
+            try? FileManager.default.removeItem(at: url1)
+            try? FileManager.default.removeItem(at: url2)
+        }
+
+        let item = ClipboardItem(
+            id: UUID(),
+            date: Date(),
+            content: .file([url1, url2]),
+            sourceBundleID: "com.apple.finder",
+            isConcealed: false,
+            concealedExpiresAt: nil,
+            isOCRResult: false
+        )
+
+        let repo = ClipboardRepository()
+        repo.saveToDisk(items: [item])
+        let loaded = repo.loadFromDisk()
+        defer { repo.clearAllFiles() }
+
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertEqual(loaded[0].sourceBundleID, "com.apple.finder")
+        if case .file(let urls) = loaded[0].content {
+            XCTAssertEqual(urls.map(\.path), [url1.path, url2.path])
+        } else {
+            XCTFail("expected .file content, got \(loaded[0].content)")
+        }
+    }
+
     func test_legacyJSONDecodesWithDefaults() throws {
         let legacyJSON = """
         [

--- a/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+++ b/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
@@ -402,6 +402,29 @@ final class ClipboardListViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_filterTagFile() async {
+        AppSettings.shared.maxItems = 10
+        AppSettings.shared.autoCleanEnabled = false
+
+        let repo = MockRepo()
+        let monitor = MockMonitor()
+        let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+        monitor.emit(ClipboardItem(date: Date(), content: .file([URL(fileURLWithPath: "/tmp/a.txt")])))
+        monitor.emit(ClipboardItem(date: Date(), content: .text("hello world")))
+
+        vm.searchText = "tag:file"
+        await MainActor.run {
+            XCTAssertEqual(vm.filteredItems.count, 1)
+            if case .file = vm.filteredItems.first?.content {
+                // OK
+            } else {
+                XCTFail("expected file content")
+            }
+        }
+    }
+
+    @MainActor
     func test_filterTagWithFromCombined() async {
         AppSettings.shared.maxItems = 10
         AppSettings.shared.autoCleanEnabled = false

--- a/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+++ b/Tests/MacClipboardTests/ClipboardListViewModelTests.swift
@@ -65,6 +65,24 @@ final class ClipboardListViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_setPasteboardForFileWritesURLs() {
+        let repo = MockRepo()
+        let monitor = MockMonitor()
+        let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+        let url = URL(fileURLWithPath: "/tmp/maclip-paste-test.txt")
+        try? Data().write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let item = ClipboardItem(date: Date(), content: .file([url]))
+        vm.setPasteboard(to: item)
+
+        let pasted = NSPasteboard.general.readObjects(forClasses: [NSURL.self],
+                                                      options: [.urlReadingFileURLsOnly: true]) as? [URL]
+        XCTAssertEqual(pasted?.first?.path, url.path)
+    }
+
+    @MainActor
     func test_setPasteboard_callsIgnoreCurrentChangeCountOnce() {
         let repo = MockRepo()
         let monitor = MockMonitor()

--- a/Tests/MacClipboardTests/ContentTagsTests.swift
+++ b/Tests/MacClipboardTests/ContentTagsTests.swift
@@ -119,4 +119,12 @@ final class ContentTagsTests: XCTestCase {
         let item = ClipboardItem(date: Date(), content: .text("hello"))
         XCTAssertNil(ContentTagDetector.primaryTag(for: item))
     }
+
+    @MainActor
+    func test_fileClipHasFileTag() {
+        let url = URL(fileURLWithPath: "/tmp/x.txt")
+        let item = ClipboardItem(date: Date(), content: .file([url]))
+        let tags = ContentTagDetector.tags(for: item)
+        XCTAssertEqual(tags, [.file])
+    }
 }

--- a/Utilities/ContentTags.swift
+++ b/Utilities/ContentTags.swift
@@ -2,7 +2,7 @@ import Foundation
 import AppKit
 
 enum ContentTag: String, CaseIterable {
-    case url, email, phone, json, code, color, diff
+    case url, email, phone, json, code, color, diff, file
 
     var symbolName: String {
         switch self {
@@ -13,6 +13,7 @@ enum ContentTag: String, CaseIterable {
         case .code:  return "chevron.left.forwardslash.chevron.right"
         case .color: return "paintpalette"
         case .diff:  return "plus.slash.minus"
+        case .file:  return "doc.on.doc"
         }
     }
 
@@ -25,6 +26,7 @@ enum ContentTag: String, CaseIterable {
         case .code:  return "Code"
         case .color: return "Color"
         case .diff:  return "Diff"
+        case .file:  return "File"
         }
     }
 }
@@ -48,7 +50,7 @@ enum ContentTagDetector {
     /// Priority order favors specificity: url > email > phone > color > json > diff > code.
     static func primaryTag(for item: ClipboardItem) -> ContentTag? {
         let tags = tags(for: item)
-        let priority: [ContentTag] = [.url, .email, .phone, .color, .json, .diff, .code]
+        let priority: [ContentTag] = [.url, .email, .phone, .color, .json, .diff, .code, .file]
         for tag in priority where tags.contains(tag) {
             return tag
         }
@@ -64,7 +66,7 @@ enum ContentTagDetector {
         case .text(let text):
             return detectTextTags(text)
         case .file:
-            return []
+            return [.file]
         }
     }
 

--- a/Utilities/ContentTags.swift
+++ b/Utilities/ContentTags.swift
@@ -63,6 +63,8 @@ enum ContentTagDetector {
             return []
         case .text(let text):
             return detectTextTags(text)
+        case .file:
+            return []
         }
     }
 

--- a/ViewModels/ClipboardListViewModel.swift
+++ b/ViewModels/ClipboardListViewModel.swift
@@ -143,6 +143,13 @@ final class ClipboardListViewModel: ObservableObject {
         }
     }
 
+    func copyToPasteboardAsText(_ string: String) {
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(string, forType: .string)
+        monitor.ignoreCurrentChangeCount()
+    }
+
     /// Decrypts image bytes stored at `url` (an `Images/*.enc` ciphertext file).
     /// Returns the plaintext PNG `Data` suitable for `NSImage(data:)`, or `nil` on failure.
     func imageData(at url: URL) -> Data? {

--- a/ViewModels/ClipboardListViewModel.swift
+++ b/ViewModels/ClipboardListViewModel.swift
@@ -213,7 +213,8 @@ final class ClipboardListViewModel: ObservableObject {
                 case .text(let t): haystack = t.lowercased()
                 case .url(let u):  haystack = u.absoluteString.lowercased()
                 case .image:       haystack = ""
-                case .file:        haystack = "" // Task 4 replaces with joined paths
+                case .file(let urls):
+                    haystack = urls.map { $0.path.lowercased() }.joined(separator: " ")
                 }
                 for token in textFilters where !haystack.contains(token) {
                     return false

--- a/ViewModels/ClipboardListViewModel.swift
+++ b/ViewModels/ClipboardListViewModel.swift
@@ -136,8 +136,10 @@ final class ClipboardListViewModel: ObservableObject {
             // Write both URL object and plain string for broad compatibility
             _ = pasteboard.writeObjects([url as NSURL])
             pasteboard.setString(url.absoluteString, forType: .string)
-        case .file:
-            break // Task 3 replaces with real write
+        case .file(let urls):
+            let nsURLs = urls.map { $0 as NSURL }
+            pasteboard.declareTypes([.fileURL], owner: nil)
+            pasteboard.writeObjects(nsURLs)
         }
     }
 

--- a/ViewModels/ClipboardListViewModel.swift
+++ b/ViewModels/ClipboardListViewModel.swift
@@ -136,6 +136,8 @@ final class ClipboardListViewModel: ObservableObject {
             // Write both URL object and plain string for broad compatibility
             _ = pasteboard.writeObjects([url as NSURL])
             pasteboard.setString(url.absoluteString, forType: .string)
+        case .file:
+            break // Task 3 replaces with real write
         }
     }
 
@@ -209,6 +211,7 @@ final class ClipboardListViewModel: ObservableObject {
                 case .text(let t): haystack = t.lowercased()
                 case .url(let u):  haystack = u.absoluteString.lowercased()
                 case .image:       haystack = ""
+                case .file:        haystack = "" // Task 4 replaces with joined paths
                 }
                 for token in textFilters where !haystack.contains(token) {
                     return false
@@ -302,6 +305,8 @@ final class ClipboardListViewModel: ObservableObject {
             case .url(let u):
                 return u.absoluteString == id || u.absoluteString == text
             case .image:
+                return false
+            case .file:
                 return false
             }
         }

--- a/ViewModels/ClipboardListViewModel.swift
+++ b/ViewModels/ClipboardListViewModel.swift
@@ -144,10 +144,18 @@ final class ClipboardListViewModel: ObservableObject {
     }
 
     func copyToPasteboardAsText(_ string: String) {
+        copyToPasteboardAsText(string, sourceBundleID: nil)
+    }
+
+    /// Writes `string` to the pasteboard and inserts a corresponding text clip at the top
+    /// of history with `sourceBundleID` attribution. Skips monitor re-capture.
+    /// Promotes existing equal-content clips instead of duplicating.
+    func copyToPasteboardAsText(_ string: String, sourceBundleID: String?) {
         let pb = NSPasteboard.general
         pb.clearContents()
         pb.setString(string, forType: .string)
         monitor.ignoreCurrentChangeCount()
+        _ = promoteOrInsertResult(text: string, sourceBundleID: sourceBundleID, isOCRResult: false)
     }
 
     /// Decrypts image bytes stored at `url` (an `Images/*.enc` ciphertext file).

--- a/Views/Components/ClipboardItemRow.swift
+++ b/Views/Components/ClipboardItemRow.swift
@@ -75,6 +75,8 @@ struct ClipboardItemRow: View {
                            isHovered: isHovered,
                            fullItem: item,
                            onRemove: onRemove)
+        case .file:
+            EmptyView() // Task 5 replaces with FileItemContent
         }
     }
 }

--- a/Views/Components/ClipboardItemRow.swift
+++ b/Views/Components/ClipboardItemRow.swift
@@ -12,6 +12,9 @@ struct ClipboardItemRow: View {
     /// Decrypts image bytes from an `Images/*.enc` URL. Required for `.file` image
     /// sources after history encryption (1.9.0); without it, the preview stays blank.
     var loadImageData: ((URL) -> Data?)? = nil
+    var onOpenFile: ((ClipboardItem) -> Void)? = nil
+    var onRevealInFinder: ((ClipboardItem) -> Void)? = nil
+    var onCopyPath: ((ClipboardItem) -> Void)? = nil
 
     @State private var isHovered: Bool = false
 
@@ -75,8 +78,20 @@ struct ClipboardItemRow: View {
                            isHovered: isHovered,
                            fullItem: item,
                            onRemove: onRemove)
-        case .file:
-            EmptyView() // Task 5 replaces with FileItemContent
+        case .file(let urls):
+            FileItemContent(
+                urls: urls,
+                date: item.date,
+                bundleID: item.sourceBundleID,
+                isConcealed: item.isConcealed,
+                concealedExpiresAt: item.concealedExpiresAt,
+                isOCRResult: item.isOCRResult,
+                isHovered: isHovered,
+                onRemove: onRemove,
+                onOpen: { onOpenFile?(item) },
+                onRevealInFinder: { onRevealInFinder?(item) },
+                onCopyPath: { onCopyPath?(item) }
+            )
         }
     }
 }
@@ -469,5 +484,108 @@ private struct RevealButton: View {
                 .help("Reveal for 5 seconds")
         }
         .buttonStyle(.plain)
+    }
+}
+
+private struct FileLeadingIcon: View {
+    let url: URL?
+    var body: some View {
+        Group {
+            if let url = url {
+                if FileManager.default.fileExists(atPath: url.path) {
+                    Image(nsImage: NSWorkspace.shared.icon(forFile: url.path))
+                        .resizable()
+                        .frame(width: 28, height: 28)
+                } else {
+                    Image(systemName: "questionmark.folder")
+                        .font(.title3)
+                        .foregroundColor(.secondary)
+                        .help("File missing")
+                }
+            } else {
+                Image(systemName: "doc")
+                    .font(.title3)
+                    .foregroundColor(.accentColor)
+            }
+        }
+    }
+}
+
+private struct FileItemContent: View {
+    let urls: [URL]
+    let date: Date
+    let bundleID: String?
+    let isConcealed: Bool
+    let concealedExpiresAt: Date?
+    let isOCRResult: Bool
+    let isHovered: Bool
+    let onRemove: () -> Void
+    let onOpen: () -> Void
+    let onRevealInFinder: () -> Void
+    let onCopyPath: () -> Void
+
+    @State private var revealedUntil: Date? = nil
+
+    private var isCurrentlyRevealed: Bool {
+        guard let revealedUntil else { return false }
+        return revealedUntil > Date()
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            FileLeadingIcon(url: urls.first)
+                .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 6) {
+                let primaryName = urls.first?.lastPathComponent ?? "(unknown)"
+                let suffix = urls.count > 1 ? " +\(urls.count - 1) more" : ""
+                let display = (isConcealed && !isCurrentlyRevealed)
+                    ? String(repeating: "•", count: min(8, max(1, primaryName.count)))
+                    : primaryName + suffix
+                Text(display)
+                    .font(.body)
+                    .lineLimit(2)
+                HStack(spacing: 8) {
+                    if let parent = urls.first?.deletingLastPathComponent().lastPathComponent {
+                        Text(parent)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                    Text(date, style: .time)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    if isConcealed {
+                        ConcealedBadge(expiresAt: concealedExpiresAt)
+                    }
+                }
+            }
+            Spacer()
+            if isConcealed && isHovered {
+                RevealButton {
+                    revealedUntil = Date().addingTimeInterval(5)
+                    Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { _ in
+                        Task { @MainActor in revealedUntil = nil }
+                    }
+                }
+            }
+            if isOCRResult {
+                OCRBadge()
+            }
+            SourceIconBadge(bundleID: bundleID)
+            if isHovered {
+                pillButton(label: "Delete", systemImage: "trash", color: .red,
+                           outlineOpacity: 0.35, fillsWidth: false, action: onRemove)
+            }
+        }
+        .padding(.trailing, 10)
+        .contextMenu {
+            Button("Open") { onOpen() }
+            Button("Reveal in Finder") { onRevealInFinder() }
+            Divider()
+            Button("Copy Path") { onCopyPath() }
+        }
+        .help(urls.prefix(10).map(\.path).joined(separator: "\n")
+              + (urls.count > 10 ? "\n(\(urls.count - 10) more)" : ""))
     }
 }

--- a/Views/Components/ClipboardItemRow.swift
+++ b/Views/Components/ClipboardItemRow.swift
@@ -33,6 +33,14 @@ struct ClipboardItemRow: View {
                     .stroke(Color.secondary.opacity((isHovered || isSelected) ? 0.35 : 0.1), lineWidth: 1)
             )
             .contextMenu {
+                // Content-specific actions first
+                if case .file = item.content {
+                    Button("Open") { onOpenFile?(item) }
+                    Button("Reveal in Finder") { onRevealInFinder?(item) }
+                    Button("Copy Path") { onCopyPath?(item) }
+                    Divider()
+                }
+                // Common action: exclude source app
                 if let bundleID = item.sourceBundleID, let onExcludeApp {
                     let name = AppMetadata.shared.displayName(for: bundleID) ?? bundleID
                     Button("Exclude \"\(name)\" from history") { onExcludeApp(bundleID) }
@@ -489,10 +497,12 @@ private struct RevealButton: View {
 
 private struct FileLeadingIcon: View {
     let url: URL?
+    @State private var exists: Bool = false
+
     var body: some View {
         Group {
             if let url = url {
-                if FileManager.default.fileExists(atPath: url.path) {
+                if exists {
                     Image(nsImage: NSWorkspace.shared.icon(forFile: url.path))
                         .resizable()
                         .frame(width: 28, height: 28)
@@ -500,14 +510,27 @@ private struct FileLeadingIcon: View {
                     Image(systemName: "questionmark.folder")
                         .font(.title3)
                         .foregroundColor(.secondary)
+                        .frame(width: 28, height: 28)
                         .help("File missing")
                 }
             } else {
                 Image(systemName: "doc")
                     .font(.title3)
                     .foregroundColor(.accentColor)
+                    .frame(width: 28, height: 28)
             }
         }
+        .onAppear {
+            recheck()
+        }
+        .onReceive(Timer.publish(every: 2, on: .main, in: .common).autoconnect()) { _ in
+            recheck()
+        }
+    }
+
+    private func recheck() {
+        guard let url else { exists = false; return }
+        exists = FileManager.default.fileExists(atPath: url.path)
     }
 }
 
@@ -579,12 +602,6 @@ private struct FileItemContent: View {
             }
         }
         .padding(.trailing, 10)
-        .contextMenu {
-            Button("Open") { onOpen() }
-            Button("Reveal in Finder") { onRevealInFinder() }
-            Divider()
-            Button("Copy Path") { onCopyPath() }
-        }
         .help(urls.prefix(10).map(\.path).joined(separator: "\n")
               + (urls.count > 10 ? "\n(\(urls.count - 10) more)" : ""))
     }

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -311,7 +311,7 @@ struct ContentView: View {
     private func copyFilePath(_ item: ClipboardItem) {
         guard case .file(let urls) = item.content else { return }
         let joined = urls.map(\.path).joined(separator: "\n")
-        viewModel.copyToPasteboardAsText(joined)
+        viewModel.copyToPasteboardAsText(joined, sourceBundleID: item.sourceBundleID)
     }
 
     private func confirmExclude(bundleID: String) {

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -240,7 +240,10 @@ struct ContentView: View {
                             onExcludeApp: { bundleID in
                                 confirmExclude(bundleID: bundleID)
                             },
-                            loadImageData: { url in viewModel.imageData(at: url) }
+                            loadImageData: { url in viewModel.imageData(at: url) },
+                            onOpenFile: { item in openFile(item) },
+                            onRevealInFinder: { item in revealInFinder(item) },
+                            onCopyPath: { item in copyFilePath(item) }
                         )
                         .id(item.id)
                         Divider()
@@ -291,6 +294,26 @@ struct ContentView: View {
         let items = viewModel.filteredItems
         guard items.indices.contains(selectedIndex) else { return }
         onSelect(items[selectedIndex])
+    }
+
+    private func openFile(_ item: ClipboardItem) {
+        guard case .file(let urls) = item.content else { return }
+        for url in urls {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func revealInFinder(_ item: ClipboardItem) {
+        guard case .file(let urls) = item.content else { return }
+        NSWorkspace.shared.activateFileViewerSelecting(urls)
+    }
+
+    private func copyFilePath(_ item: ClipboardItem) {
+        guard case .file(let urls) = item.content else { return }
+        let joined = urls.map(\.path).joined(separator: "\n")
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(joined, forType: .string)
     }
 
     private func confirmExclude(bundleID: String) {

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -311,9 +311,7 @@ struct ContentView: View {
     private func copyFilePath(_ item: ClipboardItem) {
         guard case .file(let urls) = item.content else { return }
         let joined = urls.map(\.path).joined(separator: "\n")
-        let pb = NSPasteboard.general
-        pb.clearContents()
-        pb.setString(joined, forType: .string)
+        viewModel.copyToPasteboardAsText(joined)
     }
 
     private func confirmExclude(bundleID: String) {

--- a/docs/superpowers/plans/2026-05-18-1.10.0-file-clips.md
+++ b/docs/superpowers/plans/2026-05-18-1.10.0-file-clips.md
@@ -1,0 +1,740 @@
+# MaClip 1.10.0 File & Folder Clips Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship MaClip 1.10.0 — capture file/folder copies from Finder (and elsewhere) as a new `.file([URL])` content kind, render with the file's actual NSWorkspace icon + name + parent dir, paste URLs back on click, add right-click Open/Reveal/Copy Path actions, new `ContentTag.file` for `tag:file` search.
+
+**Architecture:** New `ClipboardItemContent.file([URL])` case throughout the data model and persistence layer (encrypted at rest via the existing 1.9.0 path). `ClipboardMonitor.pollPasteboard` reads file URLs first (priority over text/image fallbacks). `ClipboardListViewModel.setPasteboard` writes URLs back as `NSPasteboardWriting`. New `FileItemContent` private subview renders the row. `ContentView` wires right-click actions to `NSWorkspace.open/activateFileViewerSelecting` and pasteboard string write.
+
+**Tech Stack:** Swift, SwiftUI, AppKit (`NSPasteboard.readObjects(forClasses:options:)`, `NSWorkspace.icon(forFile:)`, `activateFileViewerSelecting`), XCTest. Build: `xcodebuild -scheme MacClipboard -destination 'platform=macOS' test`. XcodeGen — run `xcodegen generate` if new test files don't auto-register.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-18-1.10.0-file-clips-design.md`
+
+**File map:**
+
+| File | Responsibility |
+|---|---|
+| `Models/ClipboardItem.swift` | Add `.file([URL])` case + Equatable arm |
+| `Services/ClipboardRepository.swift` | `PersistRecord.filePaths`; load/save round-trip for file clips |
+| `Services/ClipboardMonitor.swift` | Read file URLs first; emit `.file` content |
+| `ViewModels/ClipboardListViewModel.swift` | `setPasteboard` writes URLs; `filteredItems` includes file paths in haystack |
+| `Utilities/ContentTags.swift` | New `.file` enum case + detection rule + primary-tag priority |
+| `Views/Components/ClipboardItemRow.swift` | `FileItemContent` + `FileLeadingIcon` + new switch case + 3 action callbacks |
+| `Views/ContentView.swift` | Wire right-click callbacks (Open / Reveal / Copy Path) |
+| `Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift` | File round-trip test |
+| `Tests/MacClipboardTests/ContentTagsTests.swift` | File-tag test |
+| `Tests/MacClipboardTests/ClipboardListViewModelTests.swift` | `tag:file` filter test; `setPasteboard` file write test |
+| `project.yml` | Version bump 1.9.0 → 1.10.0, build 12 → 13 |
+
+---
+
+### Task 1: Data model + persistence
+
+**Files:**
+- Modify: `Models/ClipboardItem.swift`
+- Modify: `Services/ClipboardRepository.swift`
+- Modify: `Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift`
+
+Plus temporary `case .file: …` placeholders in every file that switches over `ClipboardItemContent`, replaced in Tasks 3-5.
+
+- [ ] **Step 1: Write failing test**
+
+Add to `Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift`:
+
+```swift
+func test_fileClipRoundTrips() throws {
+    let url1 = URL(fileURLWithPath: "/tmp/maclip-test-1.txt")
+    let url2 = URL(fileURLWithPath: "/tmp/maclip-test-2.txt")
+    try Data().write(to: url1)
+    try Data().write(to: url2)
+    defer {
+        try? FileManager.default.removeItem(at: url1)
+        try? FileManager.default.removeItem(at: url2)
+    }
+
+    let item = ClipboardItem(
+        id: UUID(),
+        date: Date(),
+        content: .file([url1, url2]),
+        sourceBundleID: "com.apple.finder",
+        isConcealed: false,
+        concealedExpiresAt: nil,
+        isOCRResult: false
+    )
+
+    let repo = ClipboardRepository()
+    repo.saveToDisk(items: [item])
+    let loaded = repo.loadFromDisk()
+    defer { repo.clearAllFiles() }
+
+    XCTAssertEqual(loaded.count, 1)
+    XCTAssertEqual(loaded[0].sourceBundleID, "com.apple.finder")
+    if case .file(let urls) = loaded[0].content {
+        XCTAssertEqual(urls.map(\.path), [url1.path, url2.path])
+    } else {
+        XCTFail("expected .file content, got \(loaded[0].content)")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardItemRepositoryTests/test_fileClipRoundTrips test
+```
+Expected: FAIL — `.file` case doesn't exist.
+
+- [ ] **Step 3: Add `.file([URL])` case + Equatable arm**
+
+Edit `Models/ClipboardItem.swift`. Add the case:
+
+```swift
+enum ClipboardItemContent {
+    case text(String)
+    case image(ImageContent)
+    case url(URL)
+    case file([URL])
+}
+```
+
+In `ClipboardItem`'s `Equatable` static `==` switch, add (before the default):
+
+```swift
+case let (.file(a), .file(b)):
+    return a == b
+```
+
+- [ ] **Step 4: Extend `PersistRecord` with `filePaths`**
+
+Edit `Services/ClipboardRepository.swift`. In `private struct PersistRecord: Codable`, add as the last field:
+
+```swift
+let filePaths: [String]?
+```
+
+In `loadFromDisk()`'s `for rec in records { switch rec.type { … } }` block, add a new branch:
+
+```swift
+case "file":
+    if let paths = rec.filePaths {
+        let urls = paths.map { URL(fileURLWithPath: $0) }
+        loaded.append(ClipboardItem(
+            id: rec.id, date: rec.date, content: .file(urls),
+            sourceBundleID: rec.sourceBundleID,
+            isConcealed: isConcealed,
+            concealedExpiresAt: rec.concealedExpiresAt,
+            isOCRResult: rec.isOCRResult ?? false
+        ))
+    }
+```
+
+In `performSave(items:)`'s `for item in items { switch item.content { … } }` block, add the `.file` case:
+
+```swift
+case .file(let urls):
+    records.append(PersistRecord(
+        id: item.id, date: item.date, type: "file",
+        text: nil, imageFilename: nil, url: nil,
+        cachedText: nil, cachedId: nil, cachedBarcode: nil,
+        sourceBundleID: item.sourceBundleID,
+        isConcealed: item.isConcealed,
+        concealedExpiresAt: item.concealedExpiresAt,
+        isOCRResult: item.isOCRResult,
+        filePaths: urls.map(\.path)
+    ))
+```
+
+Update all 4 existing `PersistRecord(...)` constructor sites in `performSave` (text, image-from-file, image-from-memory, url) to append `filePaths: nil` as the last argument.
+
+- [ ] **Step 5: Add placeholders for switch exhaustiveness**
+
+The new enum case will break exhaustive switches elsewhere. Add temporary stubs in:
+
+- `Utilities/ContentTags.swift` in `computeTags(for:)`:
+  ```swift
+  case .file: return []     // Task 4 replaces this with [.file]
+  ```
+- `ViewModels/ClipboardListViewModel.swift` in `filteredItems`'s `switch item.content`:
+  ```swift
+  case .file: haystack = ""  // Task 4 replaces with joined paths
+  ```
+- `ViewModels/ClipboardListViewModel.swift` in `setPasteboard(to:)`'s `switch item.content`:
+  ```swift
+  case .file: break          // Task 3 replaces with real write
+  ```
+- `Views/Components/ClipboardItemRow.swift` in `content`'s switch:
+  ```swift
+  case .file: EmptyView()    // Task 5 replaces with FileItemContent
+  ```
+
+- [ ] **Step 6: Run tests to verify pass**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests test 2>&1 | tail -5
+```
+Expected: PASS for our suites. New test passes; placeholder fallthroughs don't break anything.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Models/ClipboardItem.swift \
+        Services/ClipboardRepository.swift \
+        ViewModels/ClipboardListViewModel.swift \
+        Utilities/ContentTags.swift \
+        Views/Components/ClipboardItemRow.swift \
+        Tests/MacClipboardTests/ClipboardItemRepositoryTests.swift
+git commit -m "feat(model): add ClipboardItemContent.file([URL]) case + persistence round-trip"
+```
+
+---
+
+### Task 2: Capture file URLs in `ClipboardMonitor`
+
+**Files:**
+- Modify: `Services/ClipboardMonitor.swift`
+
+No automated test (relies on `NSPasteboard.general`). Manual QA covers.
+
+- [ ] **Step 1: Add `readFileURLs` helper**
+
+In `Services/ClipboardMonitor.swift`, add a private method (place near the existing `readImage` / `readURL` / `readText` helpers):
+
+```swift
+private func readFileURLs(from pb: NSPasteboard) -> [URL]? {
+    let opts: [NSPasteboard.ReadingOptionKey: Any] = [.urlReadingFileURLsOnly: true]
+    guard let objects = pb.readObjects(forClasses: [NSURL.self], options: opts) as? [URL],
+          !objects.isEmpty else { return nil }
+    return objects
+}
+```
+
+- [ ] **Step 2: Check file URLs first in `pollPasteboard()`**
+
+Find the section in `pollPasteboard()` AFTER `let expiry: Date? = …` but BEFORE the existing image/url/text reads. Insert:
+
+```swift
+if let urls = readFileURLs(from: pb), !urls.isEmpty {
+    subject.send(ClipboardItem(
+        date: Date(), content: .file(urls),
+        sourceBundleID: sourceBundleID,
+        isConcealed: isConcealed,
+        concealedExpiresAt: expiry
+    ))
+    return
+}
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build 2>&1 | tail -3
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Services/ClipboardMonitor.swift
+git commit -m "feat(monitor): capture file/folder URLs as .file clips"
+```
+
+---
+
+### Task 3: `setPasteboard` writes file URLs
+
+**Files:**
+- Modify: `ViewModels/ClipboardListViewModel.swift`
+- Modify: `Tests/MacClipboardTests/ClipboardListViewModelTests.swift`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `ClipboardListViewModelTests`:
+
+```swift
+@MainActor
+func test_setPasteboardForFileWritesURLs() {
+    let repo = MockRepo()
+    let monitor = MockMonitor()
+    let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+    let url = URL(fileURLWithPath: "/tmp/maclip-paste-test.txt")
+    try? Data().write(to: url)
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    let item = ClipboardItem(date: Date(), content: .file([url]))
+    vm.setPasteboard(to: item)
+
+    let pasted = NSPasteboard.general.readObjects(forClasses: [NSURL.self],
+                                                  options: [.urlReadingFileURLsOnly: true]) as? [URL]
+    XCTAssertEqual(pasted?.first?.path, url.path)
+}
+```
+
+- [ ] **Step 2: Run failing test**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardListViewModelTests/test_setPasteboardForFileWritesURLs test
+```
+Expected: FAIL — `setPasteboard` has `case .file: break` placeholder from Task 1.
+
+- [ ] **Step 3: Replace placeholder with real handling**
+
+In `ViewModels/ClipboardListViewModel.swift` `setPasteboard(to:)`, replace `case .file: break` with:
+
+```swift
+case .file(let urls):
+    let nsURLs = urls.map { $0 as NSURL }
+    pasteboard.declareTypes([.fileURL], owner: nil)
+    pasteboard.writeObjects(nsURLs)
+```
+
+Keep the `defer { monitor.ignoreCurrentChangeCount() }` at the top of `setPasteboard` intact.
+
+- [ ] **Step 4: Run test to verify pass**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ClipboardListViewModelTests test
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ViewModels/ClipboardListViewModel.swift \
+        Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+git commit -m "feat(viewmodel): paste file clips by writing NSURL objects back to pasteboard"
+```
+
+---
+
+### Task 4: `ContentTag.file` + tag detection + filter haystack
+
+**Files:**
+- Modify: `Utilities/ContentTags.swift`
+- Modify: `ViewModels/ClipboardListViewModel.swift`
+- Modify: `Tests/MacClipboardTests/ContentTagsTests.swift`
+- Modify: `Tests/MacClipboardTests/ClipboardListViewModelTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `Tests/MacClipboardTests/ContentTagsTests.swift`:
+
+```swift
+@MainActor
+func test_fileClipHasFileTag() {
+    let url = URL(fileURLWithPath: "/tmp/x.txt")
+    let item = ClipboardItem(date: Date(), content: .file([url]))
+    let tags = ContentTagDetector.tags(for: item)
+    XCTAssertEqual(tags, [.file])
+}
+```
+
+Add to `Tests/MacClipboardTests/ClipboardListViewModelTests.swift`:
+
+```swift
+@MainActor
+func test_filterTagFile() async {
+    AppSettings.shared.maxItems = 10
+    AppSettings.shared.autoCleanEnabled = false
+
+    let repo = MockRepo()
+    let monitor = MockMonitor()
+    let vm = ClipboardListViewModel(repository: repo, monitor: monitor)
+
+    monitor.emit(ClipboardItem(date: Date(), content: .file([URL(fileURLWithPath: "/tmp/a.txt")])))
+    monitor.emit(ClipboardItem(date: Date(), content: .text("hello world")))
+
+    vm.searchText = "tag:file"
+    await MainActor.run {
+        XCTAssertEqual(vm.filteredItems.count, 1)
+        if case .file = vm.filteredItems.first?.content {
+            // OK
+        } else {
+            XCTFail("expected file content")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Expected: FAIL — `ContentTag.file` doesn't exist; placeholders in `computeTags` and `filteredItems` produce wrong results.
+
+- [ ] **Step 3: Add `.file` to ContentTag enum**
+
+Edit `Utilities/ContentTags.swift`. Extend:
+
+```swift
+enum ContentTag: String, CaseIterable {
+    case url, email, phone, json, code, color, diff, file
+
+    var symbolName: String {
+        switch self {
+        case .url:   return "link"
+        case .email: return "envelope"
+        case .phone: return "phone"
+        case .json:  return "curlybraces"
+        case .code:  return "chevron.left.forwardslash.chevron.right"
+        case .color: return "paintpalette"
+        case .diff:  return "plus.slash.minus"
+        case .file:  return "doc.on.doc"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .url:   return "URL"
+        case .email: return "Email"
+        case .phone: return "Phone"
+        case .json:  return "JSON"
+        case .code:  return "Code"
+        case .color: return "Color"
+        case .diff:  return "Diff"
+        case .file:  return "File"
+        }
+    }
+}
+```
+
+In `ContentTagDetector.computeTags(for:)`, replace the placeholder `case .file: return []` with:
+
+```swift
+case .file:
+    return [.file]
+```
+
+In `ContentTagDetector.primaryTag(for:)`, extend the priority array:
+
+```swift
+let priority: [ContentTag] = [.url, .email, .phone, .color, .json, .diff, .code, .file]
+```
+
+- [ ] **Step 4: Update `filteredItems` haystack for file content**
+
+In `ViewModels/ClipboardListViewModel.swift` `filteredItems`, replace `case .file: haystack = ""` with:
+
+```swift
+case .file(let urls):
+    haystack = urls.map { $0.path.lowercased() }.joined(separator: " ")
+```
+
+The existing `tag:` parsing already handles this — `tag:file` will work automatically once `ContentTag.file` exists.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests/ContentTagsTests \
+  -only-testing:MacClipboardTests/ClipboardListViewModelTests test
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Utilities/ContentTags.swift \
+        ViewModels/ClipboardListViewModel.swift \
+        Tests/MacClipboardTests/ContentTagsTests.swift \
+        Tests/MacClipboardTests/ClipboardListViewModelTests.swift
+git commit -m "feat(tags): add ContentTag.file and tag:file filter, file-path haystack"
+```
+
+---
+
+### Task 5: `FileItemContent` + `FileLeadingIcon` row UI
+
+**Files:**
+- Modify: `Views/Components/ClipboardItemRow.swift`
+
+UI-only.
+
+- [ ] **Step 1: Add `FileLeadingIcon` helper**
+
+Append at end of `Views/Components/ClipboardItemRow.swift`:
+
+```swift
+private struct FileLeadingIcon: View {
+    let url: URL?
+    var body: some View {
+        Group {
+            if let url = url {
+                if FileManager.default.fileExists(atPath: url.path) {
+                    Image(nsImage: NSWorkspace.shared.icon(forFile: url.path))
+                        .resizable()
+                        .frame(width: 28, height: 28)
+                } else {
+                    Image(systemName: "questionmark.folder")
+                        .font(.title3)
+                        .foregroundColor(.secondary)
+                        .help("File missing")
+                }
+            } else {
+                Image(systemName: "doc")
+                    .font(.title3)
+                    .foregroundColor(.accentColor)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add `FileItemContent` subview**
+
+Append after `FileLeadingIcon`:
+
+```swift
+private struct FileItemContent: View {
+    let urls: [URL]
+    let date: Date
+    let bundleID: String?
+    let isConcealed: Bool
+    let concealedExpiresAt: Date?
+    let isOCRResult: Bool
+    let isHovered: Bool
+    let onRemove: () -> Void
+    let onOpen: () -> Void
+    let onRevealInFinder: () -> Void
+    let onCopyPath: () -> Void
+
+    @State private var revealedUntil: Date? = nil
+
+    private var isCurrentlyRevealed: Bool {
+        guard let revealedUntil else { return false }
+        return revealedUntil > Date()
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            FileLeadingIcon(url: urls.first)
+                .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 6) {
+                let primaryName = urls.first?.lastPathComponent ?? "(unknown)"
+                let suffix = urls.count > 1 ? " +\(urls.count - 1) more" : ""
+                let display = (isConcealed && !isCurrentlyRevealed)
+                    ? String(repeating: "•", count: min(8, max(1, primaryName.count)))
+                    : primaryName + suffix
+                Text(display)
+                    .font(.body)
+                    .lineLimit(2)
+                HStack(spacing: 8) {
+                    if let parent = urls.first?.deletingLastPathComponent().lastPathComponent {
+                        Text(parent)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                    Text(date, style: .time)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    if isConcealed {
+                        ConcealedBadge(expiresAt: concealedExpiresAt)
+                    }
+                }
+            }
+            Spacer()
+            if isConcealed && isHovered {
+                RevealButton {
+                    revealedUntil = Date().addingTimeInterval(5)
+                    Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { _ in
+                        Task { @MainActor in revealedUntil = nil }
+                    }
+                }
+            }
+            if isOCRResult {
+                OCRBadge()
+            }
+            SourceIconBadge(bundleID: bundleID)
+            if isHovered {
+                pillButton(label: "Delete", systemImage: "trash", color: .red,
+                           outlineOpacity: 0.35, fillsWidth: false, action: onRemove)
+            }
+        }
+        .padding(.trailing, 10)
+        .contextMenu {
+            Button("Open") { onOpen() }
+            Button("Reveal in Finder") { onRevealInFinder() }
+            Divider()
+            Button("Copy Path") { onCopyPath() }
+        }
+        .help(urls.prefix(10).map(\.path).joined(separator: "\n")
+              + (urls.count > 10 ? "\n(\(urls.count - 10) more)" : ""))
+    }
+}
+```
+
+- [ ] **Step 3: Add 3 new callback parameters + `.file` switch arm in `ClipboardItemRow`**
+
+Add to the `ClipboardItemRow` struct properties (next to existing callbacks):
+
+```swift
+var onOpenFile: ((ClipboardItem) -> Void)? = nil
+var onRevealInFinder: ((ClipboardItem) -> Void)? = nil
+var onCopyPath: ((ClipboardItem) -> Void)? = nil
+```
+
+In `ClipboardItemRow.content`, replace the placeholder `case .file: EmptyView()` (from Task 1) with:
+
+```swift
+case .file(let urls):
+    FileItemContent(
+        urls: urls,
+        date: item.date,
+        bundleID: item.sourceBundleID,
+        isConcealed: item.isConcealed,
+        concealedExpiresAt: item.concealedExpiresAt,
+        isOCRResult: item.isOCRResult,
+        isHovered: isHovered,
+        onRemove: onRemove,
+        onOpen: { onOpenFile?(item) },
+        onRevealInFinder: { onRevealInFinder?(item) },
+        onCopyPath: { onCopyPath?(item) }
+    )
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build 2>&1 | tail -3
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Views/Components/ClipboardItemRow.swift
+git commit -m "feat(row): FileItemContent subview with leading icon, context menu, stale state"
+```
+
+---
+
+### Task 6: Wire actions in `ContentView`
+
+**Files:**
+- Modify: `Views/ContentView.swift`
+
+UI-only.
+
+- [ ] **Step 1: Add 3 action handler methods**
+
+In `Views/ContentView.swift`, add private methods:
+
+```swift
+private func openFile(_ item: ClipboardItem) {
+    guard case .file(let urls) = item.content else { return }
+    for url in urls {
+        NSWorkspace.shared.open(url)
+    }
+}
+
+private func revealInFinder(_ item: ClipboardItem) {
+    guard case .file(let urls) = item.content else { return }
+    NSWorkspace.shared.activateFileViewerSelecting(urls)
+}
+
+private func copyFilePath(_ item: ClipboardItem) {
+    guard case .file(let urls) = item.content else { return }
+    let joined = urls.map(\.path).joined(separator: "\n")
+    let pb = NSPasteboard.general
+    pb.clearContents()
+    pb.setString(joined, forType: .string)
+}
+```
+
+- [ ] **Step 2: Wire callbacks into the `ClipboardItemRow(...)` instantiation**
+
+Find the `ClipboardItemRow(...)` call in the list view (where existing `onSelect`, `onRemove`, `onExtractText`, etc. are passed). Add three new closure parameters alongside:
+
+```swift
+onOpenFile: { item in openFile(item) },
+onRevealInFinder: { item in revealInFinder(item) },
+onCopyPath: { item in copyFilePath(item) }
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' build 2>&1 | tail -3
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Views/ContentView.swift
+git commit -m "feat(overlay): wire Open / Reveal in Finder / Copy Path actions for file clips"
+```
+
+---
+
+### Task 7: Manual QA
+
+Walk the 16-scenario matrix in `docs/superpowers/specs/2026-05-18-1.10.0-file-clips-design.md` § "Manual QA matrix". Mark complete when all pass.
+
+---
+
+### Task 8: Bump version to 1.10.0 (build 13)
+
+**Files:**
+- Modify: `project.yml`
+- Modify: `MacClipboard.xcodeproj/project.pbxproj` (regenerated)
+
+- [ ] **Step 1: Edit `project.yml`**
+
+```yaml
+      CURRENT_PROJECT_VERSION: 13
+      MARKETING_VERSION: 1.10.0
+```
+
+- [ ] **Step 2: Regenerate**
+
+```bash
+xcodegen generate
+```
+
+If xcscheme reverts to `MacClipboard.app`:
+
+```bash
+git checkout -- MacClipboard.xcodeproj/xcshareddata/xcschemes/MacClipboard.xcscheme
+```
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+xcodebuild -scheme MacClipboard -destination 'platform=macOS' \
+  -only-testing:MacClipboardTests test 2>&1 | tail -5
+```
+Expected: PASS for our suites.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add project.yml MacClipboard.xcodeproj/project.pbxproj
+git commit -m "chore(version): bump to 1.10.0 (build 13)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| `ClipboardItemContent.file([URL])` + Equatable | 1 |
+| `PersistRecord.filePaths` + load/save | 1 |
+| `ClipboardMonitor` file-URL capture | 2 |
+| `setPasteboard` paste back URLs | 3 |
+| `ContentTag.file` + detection + filter haystack | 4 |
+| `FileItemContent` + `FileLeadingIcon` + context menu | 5 |
+| ContentView action wiring | 6 |
+| Manual QA | 7 |
+| Version bump | 8 |
+
+**Placeholder scan:** Every code-changing step has complete code. Task 1 Step 5 uses temporary `case .file: …` fallthroughs explicitly tracked; Tasks 3-5 replace each.
+
+**Type consistency:** `.file([URL])` used identically across Tasks 1-6. `urls` parameter name consistent. `ContentTag.file` referenced identically across Tasks 4 and consumers.

--- a/docs/superpowers/specs/2026-05-18-1.10.0-file-clips-design.md
+++ b/docs/superpowers/specs/2026-05-18-1.10.0-file-clips-design.md
@@ -1,0 +1,363 @@
+# MaClip 1.10.0 — File & Folder Clips — Design
+
+**Date:** 2026-05-18
+**Status:** Approved (pending implementation plan)
+**Target version:** 1.10.0 (build 13)
+**Branch:** feature/1.10.0-files
+
+## Summary
+
+MaClip captures `⌘C` on files and folders in Finder (or anywhere that writes `public.file-url`s to the pasteboard) and stores them as a new content kind: **file clips**. The clip holds the file URLs only — no file contents are copied. Multi-selection becomes one clip with N URLs.
+
+Row UI: leading icon = first file's actual app icon (via `NSWorkspace.icon(forFile:)`); preview text = first file's name plus `+(N-1) more` for multi-selection; caption = parent directory name. Click = paste URLs back to the active app (Finder gets a copy; text apps get filename/path). Right-click adds "Open", "Reveal in Finder", "Copy Path" actions.
+
+New `ContentTag.file` so `tag:file` filters file clips in search.
+
+## Wedge
+
+Content expansion. The wedge so far (privacy + intelligent + provenance + tags + encryption at rest) has been content-blind beyond text/URL/image. File support is the next natural slice — it's what users reach for after the first three. No behavior change for existing content kinds.
+
+## Scope
+
+**In scope:**
+- New `ClipboardItemContent.file([URL])` case.
+- `ClipboardItem.Equatable` extended (file clips equal when URL arrays match).
+- `PersistRecord` extended with `filePaths: [String]?` (legacy decode tolerates).
+- `ClipboardMonitor.pollPasteboard()`: read file URLs from pasteboard (via `readObjects(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true])`); if present, emit a `.file(urls)` content. Image / text fallthrough unchanged.
+- `ClipboardListViewModel.setPasteboard(to:)`: for `.file` content, write `urls` back as `NSURL` objects.
+- New `FileItemContent` private subview in `ClipboardItemRow.swift`. Renders leading icon, preview text, caption, ghost-state for missing files.
+- New right-click context menu items "Open", "Reveal in Finder", "Copy Path" (only for `.file` content).
+- New `ContentTag.file`. Tag detection: file content type → always `[.file]`.
+- Bump version to 1.10.0 (build 13).
+
+**Out of scope:**
+- Drag-and-drop from MaClip rows to other apps (defer to 1.10.x or later).
+- Preview thumbnails for image files (defer; would re-introduce file-content reads).
+- Inline rename / edit (Idea 2 — defer to 1.10.1).
+- Symlink chasing.
+- Bookmark / security-scoped URL persistence (current macOS Application Support directory has full disk access by default for unsandboxed apps; no entitlement gymnastics needed).
+
+## Data Model
+
+`ClipboardItemContent` gains a case:
+
+```swift
+enum ClipboardItemContent {
+    case text(String)
+    case image(ImageContent)
+    case url(URL)
+    case file([URL])    // new
+}
+```
+
+`ClipboardItem.Equatable` switch adds:
+
+```swift
+case let (.file(a), .file(b)):
+    return a == b   // URL is Equatable; order-sensitive matches Finder selection order
+```
+
+(Pair this with the existing id-equality short-circuit; content-equality short-circuits dedup as already used in append.)
+
+`PersistRecord` gains:
+
+```swift
+let filePaths: [String]?    // populated when type == "file"; legacy decode tolerates nil
+```
+
+Persistence:
+- `loadFromDisk`: when `rec.type == "file"`, decode `filePaths` to `[URL]` via `URL(fileURLWithPath:)`, build `ClipboardItem(... .file(urls))`.
+- `performSave`: in `.file(let urls)` branch, append a `PersistRecord(type: "file", filePaths: urls.map(\.path), ...)`. All provenance/concealed/OCR fields forwarded per existing pattern.
+
+`ClipboardListViewModel.append`: dedup uses existing content-equality, so re-copying the same Finder selection promotes the existing clip.
+
+## Capture (ClipboardMonitor)
+
+Detection runs BEFORE existing image/url/text branches (file URLs take priority because Finder also sets text fallback that we don't want to capture as a text clip).
+
+```swift
+if let urls = readFileURLs(from: pb), !urls.isEmpty {
+    subject.send(ClipboardItem(
+        date: Date(), content: .file(urls),
+        sourceBundleID: sourceBundleID,
+        isConcealed: isConcealed,
+        concealedExpiresAt: expiry
+    ))
+    return
+}
+```
+
+```swift
+private func readFileURLs(from pb: NSPasteboard) -> [URL]? {
+    let opts: [NSPasteboard.ReadingOptionKey: Any] = [.urlReadingFileURLsOnly: true]
+    guard let objects = pb.readObjects(forClasses: [NSURL.self], options: opts) as? [URL],
+          !objects.isEmpty else { return nil }
+    return objects
+}
+```
+
+The `.urlReadingFileURLsOnly: true` option filters out non-file URLs (so a clipboard with both a file URL and an https URL won't double-emit).
+
+## Paste (ClipboardListViewModel)
+
+`setPasteboard(to:)` adds a `.file` branch:
+
+```swift
+case .file(let urls):
+    let nsURLs = urls.map { $0 as NSURL }
+    pasteboard.declareTypes([.fileURL], owner: nil)
+    pasteboard.writeObjects(nsURLs)
+```
+
+(NSURL conforms to `NSPasteboardWriting` when it represents a file URL, so the declared type is `.fileURL`. In text apps, pasting expands to the file path as a string per macOS convention.)
+
+## Row UI
+
+New private subview in `Views/Components/ClipboardItemRow.swift`:
+
+```swift
+private struct FileItemContent: View {
+    let urls: [URL]
+    let date: Date
+    let bundleID: String?
+    let isConcealed: Bool
+    let concealedExpiresAt: Date?
+    let isOCRResult: Bool
+    let isHovered: Bool
+    let onRemove: () -> Void
+    let onOpen: () -> Void
+    let onRevealInFinder: () -> Void
+    let onCopyPath: () -> Void
+
+    @State private var revealedUntil: Date? = nil
+    private var isCurrentlyRevealed: Bool {
+        guard let revealedUntil else { return false }
+        return revealedUntil > Date()
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            FileLeadingIcon(url: urls.first)
+                .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 6) {
+                let primaryName = urls.first?.lastPathComponent ?? "(unknown)"
+                let suffix = urls.count > 1 ? " +\(urls.count - 1) more" : ""
+                let display = (isConcealed && !isCurrentlyRevealed)
+                    ? String(repeating: "•", count: min(8, max(1, primaryName.count)))
+                    : primaryName + suffix
+                Text(display)
+                    .font(.body)
+                    .lineLimit(2)
+                HStack(spacing: 8) {
+                    if let parent = urls.first?.deletingLastPathComponent().lastPathComponent {
+                        Text(parent)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                    Text(date, style: .time)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    if isConcealed {
+                        ConcealedBadge(expiresAt: concealedExpiresAt)
+                    }
+                }
+            }
+            Spacer()
+            if isConcealed && isHovered {
+                RevealButton {
+                    revealedUntil = Date().addingTimeInterval(5)
+                    Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { _ in
+                        Task { @MainActor in revealedUntil = nil }
+                    }
+                }
+            }
+            if isOCRResult {
+                OCRBadge()
+            }
+            SourceIconBadge(bundleID: bundleID)
+            if isHovered {
+                pillButton(label: "Delete", systemImage: "trash", color: .red,
+                           outlineOpacity: 0.35, fillsWidth: false, action: onRemove)
+            }
+        }
+        .padding(.trailing, 10)
+        .contextMenu {
+            Button("Open") { onOpen() }
+            Button("Reveal in Finder") { onRevealInFinder() }
+            Divider()
+            Button("Copy Path") { onCopyPath() }
+        }
+        .help(urls.prefix(10).map(\.path).joined(separator: "\n")
+              + (urls.count > 10 ? "\n(\(urls.count - 10) more)" : ""))
+    }
+}
+
+private struct FileLeadingIcon: View {
+    let url: URL?
+    var body: some View {
+        Group {
+            if let url = url {
+                if FileManager.default.fileExists(atPath: url.path) {
+                    Image(nsImage: NSWorkspace.shared.icon(forFile: url.path))
+                        .resizable()
+                        .frame(width: 28, height: 28)
+                } else {
+                    Image(systemName: "questionmark.folder")
+                        .font(.title3)
+                        .foregroundColor(.secondary)
+                        .help("File missing")
+                }
+            } else {
+                Image(systemName: "doc")
+                    .font(.title3)
+                    .foregroundColor(.accentColor)
+            }
+        }
+    }
+}
+```
+
+Actions wire from the parent `ClipboardItemRow.content` switch into `ContentView`-supplied callbacks:
+
+- **Open** — `for url in urls { NSWorkspace.shared.open(url) }` (opens each with its default app).
+- **Reveal in Finder** — `NSWorkspace.shared.activateFileViewerSelecting(urls)`.
+- **Copy Path** — write `urls.map(\.path).joined(separator: "\n")` to the pasteboard via `NSPasteboard.general.setString(_:forType:)`.
+
+`ClipboardItemRow.content` switch gets a new case for `.file([URL])`. `loadImageData` plumbing not needed (no image bytes).
+
+## ContentTag
+
+`ContentTag` enum gains `case file`:
+
+```swift
+enum ContentTag: String, CaseIterable {
+    case url, email, phone, json, code, color, diff, file
+
+    var symbolName: String {
+        switch self {
+        case .url:   return "link"
+        case .email: return "envelope"
+        case .phone: return "phone"
+        case .json:  return "curlybraces"
+        case .code:  return "chevron.left.forwardslash.chevron.right"
+        case .color: return "paintpalette"
+        case .diff:  return "plus.slash.minus"
+        case .file:  return "doc.on.doc"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .url:   return "URL"
+        case .email: return "Email"
+        case .phone: return "Phone"
+        case .json:  return "JSON"
+        case .code:  return "Code"
+        case .color: return "Color"
+        case .diff:  return "Diff"
+        case .file:  return "File"
+        }
+    }
+}
+```
+
+Detection in `ContentTagDetector.computeTags(for:)`:
+
+```swift
+case .file: return [.file]
+```
+
+`primaryTag` priority order extended: `url > email > phone > color > json > diff > code > file`. (File at the end since it's content-kind tag, only set for `.file` content where it's the only tag anyway.)
+
+For file clips, the row's leading icon is the file's NSWorkspace icon (per `FileLeadingIcon` above), not the SF Symbol — so the `primaryTag`-derived icon path doesn't apply to `.file` content. The tag is still useful for `tag:file` search filtering.
+
+## Search
+
+`tag:file` filters file clips. No other search syntax changes. Free-text search matches file paths via the existing text-haystack pattern — extend the haystack to include `.file` content:
+
+```swift
+case .file(let urls): haystack = urls.map { $0.path.lowercased() }.joined(separator: " ")
+```
+
+`from:Finder` continues to work (sourceBundleID = `com.apple.finder`).
+
+## Stale Files
+
+Detection: `FileManager.default.fileExists(atPath:)` at render time on the first URL.
+
+Behavior:
+- Leading icon swaps to `questionmark.folder` SF Symbol with tooltip "File missing".
+- Click still writes the URLs to the pasteboard. Pasting in Finder will fail (Finder shows error); pasting in text apps still works (just pastes the string path).
+- Right-click "Open" and "Reveal in Finder" silently no-op when target is missing.
+- Auto-removal is OUT of scope — stale clips stay until user removes manually.
+
+## Persistence
+
+`PersistRecord` field add (Codable + optional for legacy):
+
+```swift
+private struct PersistRecord: Codable {
+    // ...existing
+    let filePaths: [String]?
+}
+```
+
+`loadFromDisk` adds the `case "file"` branch and `performSave` adds the matching write branch. All provenance/concealed/OCR fields forwarded per existing pattern. Encryption at rest from 1.9.0 applies transparently — file paths get encrypted in `history.bin` along with all other metadata.
+
+## Migration
+
+No migration. Existing histories load unchanged (new `filePaths` decodes as nil, `case "file"` doesn't apply to any legacy record).
+
+## Edge Cases
+
+1. **Empty selection** (`urls.isEmpty`) — guard in monitor; never emit empty file clips.
+2. **Pasteboard has both file URL and image** (e.g. screenshot stored as both): file branch fires first; clip is `.file`. Acceptable; matches Finder paste behavior.
+3. **Non-existent file at capture time** (rare; pasteboard URL but file deleted between copy and our poll) — ingests as file clip; row immediately shows stale state.
+4. **Very long file list (50+ URLs)** — tooltip capped to first 10 paths plus "(N more)". Row still renders only first name.
+5. **File on external volume that gets ejected** — same as stale. User unmounts → row shows missing icon.
+6. **Symbolic link** — URL is captured as-is. `NSWorkspace.icon(forFile:)` resolves icon of the resolved file. Acceptable.
+7. **Mix of files and folders in one clip** — works fine; per-URL icon resolution would matter if we showed all icons, but we show first only.
+8. **Sandboxed paste targets** — unsandboxed MaClip captures any file URL. Pasting back into sandboxed apps may require user grant; standard macOS behavior, out of MaClip's hands.
+9. **File clip from app that's later excluded** — existing exclusion logic applies (per-app `sourceBundleID` check before ingest).
+10. **Concealed file clip** — possible if source app marks pasteboard with `org.nspasteboard.ConcealedType`. Mask shows ••••• for filename; reveal eye works.
+
+## Testing
+
+### Unit tests
+
+1. **`ClipboardItemRepositoryTests`** (extend)
+   - `test_fileClipRoundTrips`: save a `.file([url1, url2])` clip → load → URLs match.
+
+2. **`ContentTagsTests`** (extend)
+   - `test_fileClipHasFileTag`: `.file([url])` content → `[.file]`.
+
+3. **`ClipboardListViewModelTests`** (extend)
+   - `test_filterTagFile`: emit a `.file` item, search `tag:file` → 1 match.
+   - `test_setPasteboardForFileWritesURLs`: `setPasteboard(to:)` with a `.file` item writes URLs to the pasteboard (verify via NSPasteboard.general post-call read).
+
+### Manual QA matrix
+
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | Select 1 file in Finder, ⌘C, ⌃⌘V | Row shows file name + parent dir + file's icon |
+| 2 | Select 3 files, ⌘C | Row shows "FirstFile.ext +2 more" + first file's icon; tooltip lists all 3 paths |
+| 3 | Click the file row | Active app gets the file URLs pasted (try in TextEdit → pastes path; in Finder folder → pastes copy of file) |
+| 4 | Right-click file row → Open | Finder opens the file with default app |
+| 5 | Right-click file row → Reveal in Finder | Finder window opens with file selected |
+| 6 | Right-click file row → Copy Path | Pasteboard gets path string(s); paste in TextEdit confirms |
+| 7 | Search `tag:file` | Only file clips visible |
+| 8 | Delete underlying file, re-open overlay | Row icon swaps to `?` ghost; tooltip says "File missing" |
+| 9 | Copy a folder from Finder | Row works the same as a file; icon is folder icon |
+| 10 | Copy mixed (file + folder selection) | One clip; first item's icon |
+| 11 | Re-copy same file selection from Finder | Existing clip promotes to top, no duplicate |
+| 12 | Quit + relaunch with file clips in history | Clips restored; encryption layer transparent |
+| 13 | Restore Privacy Defaults | File clips unaffected (not Privacy-tab-scoped) |
+| 14 | Exclude Finder via right-click | New Finder file clips not ingested; existing untouched (or purged if checkbox checked) |
+| 15 | Source icon on file clip | Finder icon (or whichever app initiated the copy) |
+| 16 | Concealed file clip via swift snippet writing ConcealedType + file URL | Filename masked; reveal eye works |
+
+## Open Questions
+
+None.

--- a/project.yml
+++ b/project.yml
@@ -26,8 +26,8 @@ targets:
       PRODUCT_NAME: MaClip
       PRODUCT_BUNDLE_IDENTIFIER: com.jokot.MacClipboard
       INFOPLIST_FILE: App/Info.plist
-      CURRENT_PROJECT_VERSION: 12
-      MARKETING_VERSION: 1.9.0
+      CURRENT_PROJECT_VERSION: 13
+      MARKETING_VERSION: 1.10.0
       DEFINES_MODULE: YES
     scheme:
       testTargets:


### PR DESCRIPTION
## Summary

- **File and folder clips.** New `ClipboardItemContent.file([URL])` content kind. `ClipboardMonitor.pollPasteboard` checks file URLs (via `readObjects(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true])`) BEFORE image/url/text branches; multi-select in Finder becomes one clip with N URLs. No file contents copied — just URLs (encrypted via the 1.9.0 layer).
- **Row UI.** `FileItemContent` subview renders the first file's `NSWorkspace.icon(forFile:)` as the leading icon, name + " +N more" suffix, parent directory + time caption. Stale-file detection (file deleted after capture) swaps to `questionmark.folder` ghost icon — re-checked on `.onAppear` and every 2 s while the row is visible.
- **Click = paste.** `setPasteboard(to:)` writes back `NSURL` objects with `declareTypes([.fileURL])` — Finder receives the file URLs (paste copies the file), text apps receive the path string.
- **Unified context menu.** `ClipboardItemRow.contextMenu` is now a single block on every row: content-specific actions (`Open`, `Reveal in Finder`, `Copy Path` for `.file`) followed by the existing `Exclude "<App>"`. Removed the inner duplicate from `FileItemContent`.
- **Copy Path.** Writes the path(s) to the pasteboard AND adds a new text clip with the original file clip's source attribution (typically Finder), instead of attributing it to whichever app happens to be frontmost when the action fires. Routes through a new `copyToPasteboardAsText(_:sourceBundleID:)` overload on the VM that delegates to `promoteOrInsertResult` for dedup.
- **`tag:file` filter.** New `ContentTag.file` (symbol `doc.on.doc`, display name "File"). Detection: any `.file` content yields `[.file]`. `tag:file` filters in search; free-text search also matches against file paths (`filteredItems` haystack extended).
- **Encryption transparent.** `PersistRecord.filePaths` is the only new schema field; file path strings get encrypted in `history.bin` alongside the rest.

Bumped to 1.10.0 (build 13).

## Test Plan

- [x] Unit: `test_fileClipRoundTrips` (encrypted round-trip preserves URLs)
- [x] Unit: `test_fileClipHasFileTag` (detection)
- [x] Unit: `test_filterTagFile` (search)
- [x] Unit: `test_setPasteboardForFileWritesURLs` (paste)
- [x] Manual QA matrix scenarios 1-9 (single file, multi-file, click-paste, right-click actions, tag:file filter, folder copy, stale file). Failures fixed mid-QA:
  - Stale file ghost icon — added `@State exists` + 2s re-check timer to force SwiftUI re-render
  - Unified context menu — moved file actions from `FileItemContent.contextMenu` to outer `ClipboardItemRow.contextMenu`
  - Copy Path attribution — VM helper now inserts new text clip via `promoteOrInsertResult` with source forwarded
- [x] Pre-existing `URLUtilsTests` failures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)